### PR TITLE
fixed build issue if "ts" is in the path

### DIFF
--- a/report-lib.pri
+++ b/report-lib.pri
@@ -244,7 +244,7 @@ all.depends = locale
 
 #"%.ts".commands = lupdate -ts $@ $<
 
-TRANSLATIONS_TARGETS = $$replace(TRANSLATIONS, ".ts", ".qm")
+TRANSLATIONS_TARGETS = $$replace(TRANSLATIONS, "\.ts", ".qm")
 locale.depends = $$TRANSLATIONS_TARGETS
 QMAKE_EXTRA_TARGETS += locale
 


### PR DESCRIPTION
Hi,

this project seems very promising at first glance, thanks!

I had an issue building the library because $$replace seems to use regex and i had another ts in the path (projects turned into proje.qm) and "." is usually anychar in regexes.

this:
.../develop/projects/LimeReport/translations/limereport_ru.qm
turned into that:
.../develop/proje.qm/LimeReport/translations/limereport_ru.qm

escaping the "." with "\" in the $$replace fixes this, but I am a QT noob, so I don't know if this is the correct solution (the $$replace documentation says nothing about regex http://doc.qt.io/qt-5/qmake-function-reference.html)

Thanks!

