### PR TITLE
Fix "hidden overloaded virtual function" warning

### DIFF
--- a/limereport/bands/lrtearoffband.h
+++ b/limereport/bands/lrtearoffband.h
@@ -12,7 +12,7 @@ public:
     virtual BaseDesignIntf* createSameTypeItem(QObject* owner=0, QGraphicsItem* parent=0);
 protected:
     QColor bandColor() const;
-    bool isUnique(){ return true;}
+    virtual bool isUnique() const {return true;}
 };
 
 } // namespace LimeReport


### PR DESCRIPTION
I'm presuming that TearOffBand::isUnique() is supposed to override the base class's isUnique(), but it was missing a const...

(If that's not the case, then consider renaming the method.)