### PR TITLE
Fix crash when cutting an item using the context menu

### DIFF
--- a/limereport/lrbasedesignintf.cpp
+++ b/limereport/lrbasedesignintf.cpp
@@ -1180,7 +1180,10 @@ void BaseDesignIntf::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
     QAction* a = menu.exec(event->screenPos());
     if (a){
         if (a == cutAction)
+        {
             page->cut();
+            return;
+        }
         if (a == copyAction)
             page->copy();
         if (a == pasteAction)


### PR DESCRIPTION
page->cut() is deleting the object, which means that "this" is no longer valid, and then we're trying to call `processPopUpAction()` on it.