### PR TITLE
Optionally monitor changes to files loaded with ReportEngine::loadFromFile()

### DIFF
--- a/include/lrreportengine.h
+++ b/include/lrreportengine.h
@@ -82,7 +82,7 @@ public:
     void    setShowProgressDialog(bool value);
     IDataSourceManager* dataManager();
     IScriptEngineManager* scriptManager();
-    bool    loadFromFile(const QString& fileName);
+    bool    loadFromFile(const QString& fileName, bool autoLoadPreviewOnChange = false);
     bool    loadFromByteArray(QByteArray *data);
     bool    loadFromString(const QString& data);
     QString reportFileName();

--- a/limereport/lrpreviewreportwindow.cpp
+++ b/limereport/lrpreviewreportwindow.cpp
@@ -136,6 +136,11 @@ void PreviewReportWindow::initPreview(int pagesCount)
     m_pagesNavigator->setValue(1);
 }
 
+void PreviewReportWindow::reloadPreview()
+{
+   m_previewReportWidget->refreshPages();
+}
+
 void PreviewReportWindow::setSettings(QSettings* value)
 {
     if (m_ownedSettings)

--- a/limereport/lrpreviewreportwindow.h
+++ b/limereport/lrpreviewreportwindow.h
@@ -60,6 +60,7 @@ public:
     void setPages(ReportPages pages);
     void exec();
     void initPreview(int pagesCount);
+    void reloadPreview();
     void setSettings(QSettings* value);
     void setErrorMessages(const QStringList& value);
     void setToolBarVisible(bool value);

--- a/limereport/lrreportdesignwidget.cpp
+++ b/limereport/lrreportdesignwidget.cpp
@@ -288,7 +288,7 @@ bool ReportDesignWidget::save()
 
 bool ReportDesignWidget::loadFromFile(const QString &fileName)
 {
-    if (m_report->loadFromFile(fileName)){
+    if (m_report->loadFromFile(fileName,false)){
         createTabs();
         //connectPage(m_report->pageAt(0));
         m_scriptEditor->setPlainText(m_report->scriptContext()->initScript());

--- a/limereport/lrreportengine.cpp
+++ b/limereport/lrreportengine.cpp
@@ -32,6 +32,7 @@
 #include <QMessageBox>
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QFileSystemWatcher>
 
 #include "time.h"
 
@@ -59,13 +60,15 @@ ReportEnginePrivate::ReportEnginePrivate(QObject *parent) :
     m_printer(new QPrinter(QPrinter::HighResolution)), m_printerSelected(false),
     m_showProgressDialog(true), m_reportName(""), m_activePreview(0),
     m_previewWindowIcon(":/report/images/logo32"), m_previewWindowTitle(tr("Preview")),
-    m_reportRendering(false), m_resultIsEditable(true), m_passPhrase("HjccbzHjlbyfCkjy")
+    m_reportRendering(false), m_resultIsEditable(true), m_passPhrase("HjccbzHjlbyfCkjy"),
+    m_fileWatcher( new QFileSystemWatcher( this ) )
 {
     m_datasources = new DataSourceManager(this);
     m_datasources->setReportSettings(&m_reportSettings);
     m_scriptEngineContext = new ScriptEngineContext(this);
     m_datasources->setObjectName("datasources");
     connect(m_datasources,SIGNAL(loadCollectionFinished(QString)),this,SLOT(slotDataSourceCollectionLoaded(QString)));
+    connect(m_fileWatcher,SIGNAL(fileChanged(const QString &)),this,SLOT(slotLoadFromFile(const QString &)));
 }
 
 ReportEnginePrivate::~ReportEnginePrivate()
@@ -457,6 +460,63 @@ void ReportEnginePrivate::setCurrentReportsDir(const QString &dirName)
         m_reportsDir = dirName;
 }
 
+bool ReportEnginePrivate::slotLoadFromFile(const QString &fileName)
+{
+    PreviewReportWindow  *currentPreview = qobject_cast<PreviewReportWindow *>(m_activePreview);
+   
+    if (!QFile::exists(fileName))
+    {
+       if ( hasActivePreview() )
+       {          
+          QMessageBox::information( NULL,
+                                    tr( "Report File Change" ),
+                                    tr( "The report file \"%1\" has changed names or been deleted.\n\nThis preview is no longer valid." ).arg( fileName )
+                                    );
+          
+          clearReport();
+          
+          currentPreview->close();
+       }
+       
+       return false;
+    }
+
+    clearReport();
+
+    ItemsReaderIntf::Ptr reader = FileXMLReader::create(fileName);
+    reader->setPassPhrase(m_passPhrase);
+    if (reader->first()){
+        if (reader->readItem(this)){
+            m_fileName=fileName;
+            QFileInfo fi(fileName);
+            m_reportName = fi.fileName();
+
+            QString dbSettingFileName = fi.absolutePath()+"/"+fi.baseName()+".db";
+            if (QFile::exists(dbSettingFileName)){
+                QSettings dbcredentals(dbSettingFileName, QSettings::IniFormat);
+                foreach (ConnectionDesc* connection, dataManager()->conections()) {
+                    if (!connection->keepDBCredentials()){
+                        dbcredentals.beginGroup(connection->name());
+                        connection->setUserName(dbcredentals.value("user").toString());
+                        connection->setPassword(dbcredentals.value("password").toString());
+                        dbcredentals.endGroup();
+                    }
+                }
+            }
+
+            dataManager()->connectAutoConnections();
+
+            if ( hasActivePreview() )
+            {
+               currentPreview->reloadPreview();
+            }
+            return true;
+        };
+    }
+    m_lastError = reader->lastError();
+    return false;
+}
+
 void ReportEnginePrivate::cancelRender()
 {
     if (m_reportRender)
@@ -509,39 +569,20 @@ QSettings*ReportEnginePrivate::settings()
     }
 }
 
-bool ReportEnginePrivate::loadFromFile(const QString &fileName)
+bool ReportEnginePrivate::loadFromFile(const QString &fileName, bool autoLoadPreviewOnChange)
 {
-    if (!QFile::exists(fileName)) return false;
+   // only watch one file at a time
+   if ( !m_fileWatcher->files().isEmpty() )
+   {
+      m_fileWatcher->removePaths( m_fileWatcher->files() );
+   }
 
-    clearReport();    
+   if ( autoLoadPreviewOnChange )
+   {
+      m_fileWatcher->addPath( fileName );
+   }
 
-    ItemsReaderIntf::Ptr reader = FileXMLReader::create(fileName);
-    reader->setPassPhrase(m_passPhrase);
-    if (reader->first()){
-        if (reader->readItem(this)){
-            m_fileName=fileName;
-            QFileInfo fi(fileName);
-            m_reportName = fi.fileName();
-
-            QString dbSettingFileName = fi.absolutePath()+"/"+fi.baseName()+".db";
-            if (QFile::exists(dbSettingFileName)){
-                QSettings dbcredentals(dbSettingFileName, QSettings::IniFormat);
-                foreach (ConnectionDesc* connection, dataManager()->conections()) {
-                    if (!connection->keepDBCredentials()){
-                        dbcredentals.beginGroup(connection->name());
-                        connection->setUserName(dbcredentals.value("user").toString());
-                        connection->setPassword(dbcredentals.value("password").toString());
-                        dbcredentals.endGroup();
-                    }
-                }
-            }
-
-            dataManager()->connectAutoConnections();
-            return true;
-        };
-    }   
-    m_lastError = reader->lastError();
-    return false;
+   return slotLoadFromFile( fileName );
 }
 
 bool ReportEnginePrivate::loadFromByteArray(QByteArray* data, const QString &name){
@@ -880,10 +921,10 @@ IScriptEngineManager* ReportEngine::scriptManager()
     return d->scriptManagerIntf();
 }
 
-bool ReportEngine::loadFromFile(const QString &fileName)
+bool ReportEngine::loadFromFile(const QString &fileName, bool autoLoadPreviewOnChange)
 {
     Q_D(ReportEngine);
-    return d->loadFromFile(fileName);
+    return d->loadFromFile(fileName, autoLoadPreviewOnChange);
 }
 
 bool ReportEngine::loadFromByteArray(QByteArray* data){

--- a/limereport/lrreportengine.cpp
+++ b/limereport/lrreportengine.cpp
@@ -155,7 +155,7 @@ void ReportEnginePrivate::slotDataSourceCollectionLoaded(const QString &collecti
     emit datasourceCollectionLoadFinished(collectionName);
 }
 
-void ReportEnginePrivate::slotPreviewWindowDestroed(QObject* window)
+void ReportEnginePrivate::slotPreviewWindowDestroyed(QObject* window)
 {
     if (m_activePreview == window){
         m_activePreview = 0;
@@ -387,7 +387,7 @@ void ReportEnginePrivate::previewReport(PreviewHints hints)
             w->setHideResultEditButton(resultIsEditable());
 
             m_activePreview = w;
-            connect(w,SIGNAL(destroyed(QObject*)), this, SLOT(slotPreviewWindowDestroed(QObject*)));
+            connect(w,SIGNAL(destroyed(QObject*)), this, SLOT(slotPreviewWindowDestroyed(QObject*)));
             qDebug()<<"render time ="<<start.msecsTo(QTime::currentTime());
             w->exec();
         }

--- a/limereport/lrreportengine.h
+++ b/limereport/lrreportengine.h
@@ -82,7 +82,7 @@ public:
     void    setShowProgressDialog(bool value);
     IDataSourceManager* dataManager();
     IScriptEngineManager* scriptManager();
-    bool    loadFromFile(const QString& fileName);
+    bool    loadFromFile(const QString& fileName, bool autoLoadPreviewOnChange = false);
     bool    loadFromByteArray(QByteArray *data);
     bool    loadFromString(const QString& data);
     QString reportFileName();

--- a/limereport/lrreportengine_p.h
+++ b/limereport/lrreportengine_p.h
@@ -42,6 +42,8 @@
 #include "serializators/lrstorageintf.h"
 #include "lrscriptenginemanager.h"
 
+class QFileSystemWatcher;
+
 namespace LimeReport{
 
 class PageDesignIntf;
@@ -91,7 +93,7 @@ public:
     void    setSettings(QSettings* value);
     void    setShowProgressDialog(bool value){m_showProgressDialog = value;}
     QSettings*  settings();
-    bool    loadFromFile(const QString& fileName);
+    bool    loadFromFile(const QString& fileName, bool autoLoadPreviewOnChange);
     bool    loadFromByteArray(QByteArray *data, const QString& name = "");
     bool    loadFromString(const QString& report, const QString& name = "");
     QString reportFileName(){return m_fileName;}
@@ -138,6 +140,7 @@ signals:
     void    onSave();
     void    saveFinished();
 public slots:
+    bool    slotLoadFromFile(const QString& fileName);
     void    cancelRender();
 protected:
     PageDesignIntf* createPage(const QString& pageName="");
@@ -178,6 +181,8 @@ private:
     bool m_reportRendering;
     bool m_resultIsEditable;
     QString m_passPhrase;
+
+    QFileSystemWatcher  *m_fileWatcher;
 };
 
 }

--- a/limereport/lrreportengine_p.h
+++ b/limereport/lrreportengine_p.h
@@ -144,7 +144,7 @@ protected:
 protected slots:
     void    slotDataSourceCollectionLoaded(const QString& collectionName);
 private slots:
-    void slotPreviewWindowDestroed(QObject *window);
+    void slotPreviewWindowDestroyed(QObject *window);
 private:
     //ICollectionContainer
     virtual QObject*    createElement(const QString&,const QString&);


### PR DESCRIPTION
When using the designer as a stand alone application and the renderer/preview in the
user application, the preview window would have to be closed and opened again every
time a change was made to the report.

This change adds an optional QFileSystemWatcher to monitor changes to the report file
and automatically refreshes the preview in the application when it is saved.

It may be turned on using the new parameter to ReportEngine::loadFromFile().

If the preview window is open in the application and the file name changes or the file is
removed, inform the user and close the preview window.