### PR TITLE
Debug compile target improvings

### DIFF
--- a/3rdparty/zint-2.4.4/backend_qt4/Zint.pro
+++ b/3rdparty/zint-2.4.4/backend_qt4/Zint.pro
@@ -26,7 +26,11 @@ unix{
 
 INCLUDEPATH += $$PWD/../backend
 DEFINES +=  _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS ZINT_VERSION=\\\"$$VERSION\\\"
-TARGET = QtZint
+contains(CONFIG,release) {
+	TARGET = QtZint
+} else {
+	TARGET = QtZintd
+}
 
 !contains(DEFINES, NO_PNG) {
     SOURCES += $$PWD/../backend/png.c

--- a/demo_r1/demo_r1.pro
+++ b/demo_r1/demo_r1.pro
@@ -1,7 +1,12 @@
 include(../common.pri)
 QT += core gui
 
-TARGET = LRDemo_r1
+contains(CONFIG,release) {
+	TARGET = LRDemo_r1
+} else {
+	TARGET = LRDemo_r1d
+}
+
 TEMPLATE = app
 
 SOURCES += main.cpp\
@@ -60,7 +65,12 @@ win32 {
             LIBS += -L$${DEST_LIBS} -lQtZint
         }
     }
-    LIBS += -L$${DEST_LIBS} -llimereport
+    LIBS += -L$${DEST_LIBS}
+	contains(CONFIG,release) {
+		LIBS += -llimereport
+	} else {
+		LIBS += -llimereportd
+	}
 }
 
 

--- a/demo_r2/demo_r2.pro
+++ b/demo_r2/demo_r2.pro
@@ -1,7 +1,12 @@
 include(../common.pri)
 QT += core gui
 
-TARGET = LRDemo_r2
+contains(CONFIG,release) {
+	TARGET = LRDemo_r2
+} else {
+	TARGET = LRDemo_r2d
+}
+
 TEMPLATE = app
 
 SOURCES += main.cpp\
@@ -57,7 +62,12 @@ win32 {
             LIBS += -L$${DEST_LIBS} -lQtZint
         }
     }
-    LIBS += -L$${DEST_LIBS} -llimereport
+    LIBS += -L$${DEST_LIBS}
+	contains(CONFIG,release) {
+		LIBS += -llimereport
+	} else {
+		LIBS += -llimereportd
+	}
 
     QMAKE_POST_LINK += $$QMAKE_COPY_DIR $$shell_quote($$EXTRA_DIR\\*) $$shell_quote($$REPORTS_DIR\\demo_reports) $$escape_expand(\\n\\t)
 }

--- a/designer/designer.pro
+++ b/designer/designer.pro
@@ -1,7 +1,11 @@
 include(../common.pri)
 QT += core gui
 
-TARGET = LRDesigner
+contains(CONFIG,release) {
+	TARGET = LRDesigner
+} else {
+	TARGET = LRDesignerd
+}
 TEMPLATE = app
 
 SOURCES += main.cpp
@@ -47,6 +51,11 @@ win32 {
             LIBS += -L$${DEST_LIBS} -lQtZint
         }
     }
-    LIBS += -L$${DEST_LIBS} -llimereport
+    LIBS += -L$${DEST_LIBS}
+	contains(CONFIG,release) {
+		LIBS += -llimereport
+	} else {
+		LIBS += -llimereportd
+	}
 }
 

--- a/limereport/limereport.pro
+++ b/limereport/limereport.pro
@@ -1,4 +1,9 @@
-TARGET = limereport
+contains(CONFIG,release) {
+	TARGET = limereport
+} else {
+	TARGET = limereportd
+}
+
 TEMPLATE = lib
 
 contains(CONFIG, static_build){
@@ -73,7 +78,12 @@ contains(CONFIG,zint){
     message(zint)
     INCLUDEPATH += $$ZINT_PATH/backend $$ZINT_PATH/backend_qt4
     DEPENDPATH += $$ZINT_PATH/backend $$ZINT_PATH/backend_qt4
-    LIBS += -L$${DEST_LIBS} -lQtZint
+	LIBS += -L$${DEST_LIBS}
+	contains(CONFIG,release) {
+		LIBS += -lQtZint
+	} else {
+		LIBS += -lQtZintd
+	}
 }
 
 #######


### PR DESCRIPTION
Hi,

to make it more easy to work with debug and release binaries in the same destination directory append a "d" to the Target binaries (if compile in debug mode) and also link to these debugging files.

This also fixes issues in windows if you link your release binary against a debug binary and vice versa.