### PR TITLE
Fix re-enabling subdetail checkbox

### DIFF
--- a/limereport/databrowser/lrsqleditdialog.cpp
+++ b/limereport/databrowser/lrsqleditdialog.cpp
@@ -278,6 +278,7 @@ void SQLEditDialog::initSubQueryMode()
     ui->leMaster->setVisible(true);
     ui->leMaster->setEnabled(true);
     ui->lbMaster->setVisible(true);
+    ui->cbSubdetail->setEnabled(true);
 
 }
 


### PR DESCRIPTION
When clicking around, I found that it wasn't re-enabling