### PR TITLE
Report Engine:

### DIFF
--- a/include/lrreportengine.h
+++ b/include/lrreportengine.h
@@ -119,13 +119,12 @@ signals:
     void renderStarted();
     void renderFinished();
     void renderPageFinished(int renderedPageCount);
+    void onSave(bool& saved);
+    void onSaveAs(bool& saved);
     void onLoad(bool& loaded);
-    void onSave();
     void saveFinished();
-
-    void loaded();
+    void loadFinished();
     void printedToPDF(QString fileName);
-
     void getAviableLanguages(QList<QLocale::Language>* languages);
     void currentDefaulLanguageChanged(QLocale::Language);
     QLocale::Language getCurrentDefaultLanguage();

--- a/limereport/lrreportdesignwidget.cpp
+++ b/limereport/lrreportdesignwidget.cpp
@@ -79,7 +79,7 @@ ReportDesignWidget::ReportDesignWidget(ReportEnginePrivateInterface* report, QMa
 
     connect(dynamic_cast<QObject*>(m_report), SIGNAL(pagesLoadFinished()),this,SLOT(slotPagesLoadFinished()));
     connect(dynamic_cast<QObject*>(m_report), SIGNAL(cleared()), this, SIGNAL(cleared()));
-    connect(dynamic_cast<QObject*>(m_report), SIGNAL(loaded()), this, SLOT(slotReportLoaded()));
+    connect(dynamic_cast<QObject*>(m_report), SIGNAL(loadFinished()), this, SLOT(slotReportLoaded()));
 
     connect(m_tabWidget, SIGNAL(currentChanged(int)), this, SLOT(slotCurrentTabChanged(int)));
 #ifdef HAVE_UI_LOADER
@@ -432,14 +432,15 @@ bool ReportDesignWidget::save()
 
     bool result = false;
 
-    if (!m_report->reportFileName().isEmpty()){
+    if (emitSaveReport()) {
+        result = true; // saved via signal
+    }
+    else if (!m_report->reportFileName().isEmpty()){
         if (m_report->saveToFile()){
             m_report->emitSaveFinished();
             result = true;
         }
-    }
-    else {
-        m_report->emitSaveReport();
+    } else {
         if (m_report->isSaved()) {
             m_report->emitSaveFinished();
             result = true;
@@ -449,6 +450,7 @@ bool ReportDesignWidget::save()
             result = true;
         };
     }
+
 #ifdef HAVE_QTDESIGNER_INTEGRATION
     if (result){
         m_dialogChanged = false;
@@ -492,6 +494,16 @@ bool ReportDesignWidget::isNeedToSave()
     if(m_report)
         return (m_report->isNeedToSave() || m_dialogChanged);
     return false;
+}
+
+bool ReportDesignWidget::emitSaveReport()
+{
+    return m_report->emitSaveReport();
+}
+
+bool ReportDesignWidget::emitSaveReportAs()
+{
+    return m_report->emitSaveReportAs();
 }
 
 bool ReportDesignWidget::emitLoadReport()

--- a/limereport/lrreportdesignwidget.h
+++ b/limereport/lrreportdesignwidget.h
@@ -108,6 +108,8 @@ public:
     ReportEnginePrivateInterface* report(){return m_report;}
     QString reportFileName();
     bool isNeedToSave();
+    bool emitSaveReport();
+    bool emitSaveReportAs();
     bool emitLoadReport();
     void saveState(QSettings *settings);
     void loadState(QSettings *settings);

--- a/limereport/lrreportengine.cpp
+++ b/limereport/lrreportengine.cpp
@@ -585,9 +585,18 @@ PageDesignIntf* ReportEnginePrivate::createPreviewScene(QObject* parent){
     return result;
 }
 
-void ReportEnginePrivate::emitSaveReport()
+bool ReportEnginePrivate::emitSaveReport()
 {
-    emit onSave();
+    bool result = false;
+    emit onSave(result);
+    return result;
+}
+
+bool ReportEnginePrivate::emitSaveReportAs()
+{
+    bool result = false;
+    emit onSaveAs(result);
+    return result;
 }
 
 bool ReportEnginePrivate::emitLoadReport()
@@ -600,6 +609,11 @@ bool ReportEnginePrivate::emitLoadReport()
 void ReportEnginePrivate::emitSaveFinished()
 {
     emit saveFinished();
+}
+
+void ReportEnginePrivate::emitLoadFinished()
+{
+    emit loadFinished();
 }
 
 void ReportEnginePrivate::emitPrintedToPDF(QString fileName)
@@ -750,7 +764,7 @@ bool ReportEnginePrivate::loadFromFile(const QString &fileName, bool autoLoadPre
 
    bool result = slotLoadFromFile( fileName );
    if (result) {
-       emit loaded();
+       emit loadFinished();
    }
    return result;
 }
@@ -764,7 +778,7 @@ bool ReportEnginePrivate::loadFromByteArray(QByteArray* data, const QString &nam
         if (reader->readItem(this)){
             m_fileName = "";
             m_reportName = name;
-            emit loaded();
+            emit loadFinished();
             return true;
         };
     }
@@ -781,7 +795,7 @@ bool ReportEnginePrivate::loadFromString(const QString &report, const QString &n
         if (reader->readItem(this)){
             m_fileName = "";
             m_reportName = name;
-            emit loaded();
+            emit loadFinished();
             return true;
         };
     }
@@ -1162,11 +1176,11 @@ ReportEngine::ReportEngine(QObject *parent)
     connect(d, SIGNAL(renderPageFinished(int)),
             this, SIGNAL(renderPageFinished(int)));
     connect(d, SIGNAL(renderFinished()), this, SIGNAL(renderFinished()));
-    connect(d, SIGNAL(onSave()), this, SIGNAL(onSave()));
+    connect(d, SIGNAL(onSave(bool&)), this, SIGNAL(onSave(bool&)));
+    connect(d, SIGNAL(onSaveAs(bool&)), this, SIGNAL(onSaveAs(bool&)));
     connect(d, SIGNAL(onLoad(bool&)), this, SIGNAL(onLoad(bool&)));
     connect(d, SIGNAL(saveFinished()), this, SIGNAL(saveFinished()));
-
-    connect(d, SIGNAL(loaded()), this, SIGNAL(loaded()));
+    connect(d, SIGNAL(loadFinished()), this, SIGNAL(loadFinished()));
     connect(d, SIGNAL(printedToPDF(QString)), this, SIGNAL(printedToPDF(QString)));
     
     connect(d, SIGNAL(getAviableLanguages(QList<QLocale::Language>*)),

--- a/limereport/lrreportengine.h
+++ b/limereport/lrreportengine.h
@@ -119,11 +119,11 @@ signals:
     void renderStarted();
     void renderFinished();
     void renderPageFinished(int renderedPageCount);
+    void onSave(bool& saved);
+    void onSaveAs(bool& saved);
     void onLoad(bool& loaded);
-    void onSave();
     void saveFinished();
-
-    void loaded();
+    void loadFinished();
     void printedToPDF(QString fileName);
 
     void getAviableLanguages(QList<QLocale::Language>* languages);

--- a/limereport/lrreportengine_p.h
+++ b/limereport/lrreportengine_p.h
@@ -67,14 +67,16 @@ public:
     virtual DataSourceManager*      dataManager() = 0;
     virtual QString                 reportFileName() = 0;
     virtual void                    setReportFileName(const QString& reportFileName) = 0;
-    virtual void                    emitSaveFinished() = 0;
     virtual bool                    isNeedToSave() = 0;
-    virtual void                    emitSaveReport() = 0;
+    virtual bool                    emitSaveReport() = 0;
+    virtual bool                    emitSaveReportAs() = 0;
+    virtual void                    emitSaveFinished() = 0;
     virtual bool                    saveToFile(const QString& fileName = "") = 0;
     virtual bool                    isSaved() = 0;
     virtual QString                 reportName() = 0;
     virtual bool                    loadFromFile(const QString& fileName, bool autoLoadPreviewOnChange) = 0;
     virtual bool                    emitLoadReport() = 0;
+    virtual void                    emitLoadFinished() = 0;
     virtual void                    clearSelection() = 0;
     virtual bool                    printReport(QPrinter *printer=0) = 0;
     virtual void                    previewReport(PreviewHints hints = PreviewBarsUserSetting) = 0;
@@ -148,9 +150,11 @@ public:
     bool    isNeedToSave();
     QString lastError();
     ReportEngine * q_ptr;
-    void emitSaveReport();
+    bool emitSaveReport();
+    bool emitSaveReportAs();
     bool emitLoadReport();
     void emitSaveFinished();
+    void emitLoadFinished();
     void emitPrintedToPDF(QString fileName);
     bool isSaved();
     void setCurrentReportsDir(const QString& dirName);
@@ -193,11 +197,11 @@ signals:
     void    renderStarted();
     void    renderFinished();
     void    renderPageFinished(int renderedPageCount);
+    void    onSave(bool& saved);
+    void    onSaveAs(bool& saved);
     void    onLoad(bool& loaded);
-    void    onSave();
     void    saveFinished();
-
-    void    loaded();
+    void    loadFinished();
     void    printedToPDF(QString fileName);
 
     void    getAviableLanguages(QList<QLocale::Language>* languages);

--- a/limereport/objectsbrowser/lrobjectbrowser.cpp
+++ b/limereport/objectsbrowser/lrobjectbrowser.cpp
@@ -51,7 +51,7 @@ void ObjectBrowser::setReportEditor(ReportDesignWidget *report)
 {
     m_report=report;
     connect(m_report,SIGNAL(cleared()),this,SLOT(slotClear()));
-    connect(m_report, SIGNAL(loaded()), this, SLOT(slotReportLoaded()));
+    connect(m_report, SIGNAL(loadFinished()), this, SLOT(slotReportLoaded()));
     connect(m_report, SIGNAL(activePageChanged()), this, SLOT(slotActivePageChanged()));
 
     connect(m_report,SIGNAL(itemAdded(LimeReport::PageDesignIntf*,LimeReport::BaseDesignIntf*)),

--- a/limereport/scriptbrowser/lrscriptbrowser.cpp
+++ b/limereport/scriptbrowser/lrscriptbrowser.cpp
@@ -58,7 +58,7 @@ void ScriptBrowser::setReportEditor(ReportDesignWidget* report)
 {
     m_report=report;
     connect(m_report,SIGNAL(cleared()),this,SLOT(slotClear()));
-    connect(m_report,SIGNAL(loaded()),this,SLOT(slotUpdate()));
+    connect(m_report,SIGNAL(loadFinished()),this,SLOT(slotUpdate()));
 #ifdef HAVE_UI_LOADER
     connect(m_report->scriptContext(), SIGNAL(dialogAdded(QString)), this, SLOT(slotDialogAdded(QString)));
 #endif

--- a/limereport/scriptbrowser/lrscriptbrowser.cpp
+++ b/limereport/scriptbrowser/lrscriptbrowser.cpp
@@ -58,7 +58,7 @@ void ScriptBrowser::setReportEditor(ReportDesignWidget* report)
 {
     m_report=report;
     connect(m_report,SIGNAL(cleared()),this,SLOT(slotClear()));
-    connect(m_report,SIGNAL(loadFinished()),this,SLOT(slotUpdate()));
+    connect(m_report,SIGNAL(loaded()),this,SLOT(slotUpdate()));
 #ifdef HAVE_UI_LOADER
     connect(m_report->scriptContext(), SIGNAL(dialogAdded(QString)), this, SLOT(slotDialogAdded(QString)));
 #endif


### PR DESCRIPTION

### Example of replacing LimeReportWindow's save/saveas/load actions

Why? Instead of saving a report to a '.lrxml' file, you might save to a database

```cpp
LimeReport::ReportEngine reportEngine;

QObject::connect(&reportEngine, &LimeReport::ReportEngine::onSave,
    [this](bool& saved) {
    // Do something to save report..

    MySaveDialog dialog;
    dialog.exec();
    QByteArray data = reportEngine.saveToByteArray();
    myCustomSaveFunction(data);

    // Make sure whatever function(s) you call have emitted signal 
    // 'reportEngine::saveFinished'. In this case, its saveToByteArray().

    saved = true; // completes the 'interception' of the onSave signal
                  // prevents LimeReportWindow from its default save
});
QObject::connect(&reportEngine, &LimeReport::ReportEngine::onSaveAs,
                  [this](bool& saved) { /* ... */ });
QObject::connect(&reportEngine, &LimeReport::ReportEngine::onLoad,
                  [this](bool& loaded) { /* ... */ });
QObject::connect(&reportEngine, &LimeReport::ReportEngine::loadFinished,
                  [this]() { qDebug() << "loadFinished"; });
QObject::connect(&reportEngine, &LimeReport::ReportEngine::saveFinished,
                  [this]() { qDebug() << "saveFinished"; });
```