### PR TITLE
Forward ReportEnginePrivate::cleared signal to ReportEngine::cleared

### DIFF
--- a/limereport/lrreportengine.cpp
+++ b/limereport/lrreportengine.cpp
@@ -1181,6 +1181,7 @@ ReportEngine::ReportEngine(QObject *parent)
     connect(d, SIGNAL(onLoad(bool&)), this, SIGNAL(onLoad(bool&)));
     connect(d, SIGNAL(saveFinished()), this, SIGNAL(saveFinished()));
     connect(d, SIGNAL(loadFinished()), this, SIGNAL(loadFinished()));
+    connect(d, SIGNAL(cleared()), this, SIGNAL(cleared()));
     connect(d, SIGNAL(printedToPDF(QString)), this, SIGNAL(printedToPDF(QString)));
     
     connect(d, SIGNAL(getAviableLanguages(QList<QLocale::Language>*)),

--- a/limereport/lrreportengine.h
+++ b/limereport/lrreportengine.h
@@ -116,6 +116,7 @@ public:
     QList<QLocale::Language> designerLanguages();
     QLocale::Language currentDesignerLanguage();
 signals:
+    void cleared();
     void renderStarted();
     void renderFinished();
     void renderPageFinished(int renderedPageCount);


### PR DESCRIPTION
s.t. users of  LimeReport as a library are informed when a user clicks the new report Action