### PR TITLE
Test more Qt versions and fix compilation errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,548 @@
-language: cpp
+matrix:
+    include:         
+      - env: Qt4.8.5_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            packages:
+              - qt4-default
+            
+        script:
+          - qmake -r limereport.pro
+          - make
+          - make check
 
-compiler:
-  - gcc
+      - env: Qt4.8.5_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            packages:
+              - qt4-default
+            
+        script:
+          - qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.1.1_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt511-trusty'
+            packages:
+              - qt51base
+              - qt51script
+              - qt51tools
+            
+        script:
+          - source /opt/qt51/bin/qt51-env.sh
+          - /opt/qt51/bin/qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.1.1_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt511-trusty'
+            packages:
+              - qt51base
+              - qt51script
+              - qt51tools
+            
+        script:
+          - source /opt/qt51/bin/qt51-env.sh
+          - /opt/qt51/bin/qmake -r limereport.pro
+          - make
+          - make check
 
-sudo: required
-dist: trusty
+      - env: Qt5.2.1_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt521-trusty'
+            packages:
+              - qt52base
+              - qt52script
+              - qt52tools
+            
+        script:
+          - source /opt/qt52/bin/qt52-env.sh
+          - /opt/qt52/bin/qmake -r limereport.pro
+          - make
+          - make check
 
-env:
-  - QT_BASE=56
+      - env: Qt5.2.1_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt521-trusty'
+            packages:
+              - qt52base
+              - qt52script
+              - qt52tools
+            
+        script:
+          - source /opt/qt52/bin/qt52-env.sh
+          - /opt/qt52/bin/qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.3.2_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt532-trusty'
+            packages:
+              - qt53base
+              - qt53script
+              - qt53tools
+            
+        script:
+          - source /opt/qt53/bin/qt53-env.sh
+          - /opt/qt53/bin/qmake -r limereport.pro
+          - make
+          - make check
 
-before_install:
-  - if [ "$QT_BASE" = "56" ]; then sudo add-apt-repository ppa:beineri/opt-qt562-trusty -y; fi
-  - sudo apt-get update -qq
+      - env: Qt5.3.2_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt532-trusty'
+            packages:
+              - qt53base
+              - qt53script
+              - qt53tools
+            
+        script:
+          - source /opt/qt53/bin/qt53-env.sh
+          - /opt/qt53/bin/qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.4.2_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt542-trusty'
+            packages:
+              - qt54base
+              - qt54script
+              - qt54tools
+            
+        script:
+          - source /opt/qt54/bin/qt54-env.sh
+          - /opt/qt54/bin/qmake -r limereport.pro
+          - make
+          - make check
 
-install:
-  - if [ "$QT_BASE" = "56" ]; then sudo apt-get install -qq qt56base qt56script qt56tools ; source /opt/qt56/bin/qt56-env.sh; fi
-  
+      - env: Qt5.4.2_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt542-trusty'
+            packages:
+              - qt54base
+              - qt54script
+              - qt54tools
+            
+        script:
+          - source /opt/qt54/bin/qt54-env.sh
+          - /opt/qt54/bin/qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.5.1_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt551-trusty'
+            packages:
+              - qt55base
+              - qt55script
+              - qt55tools
+            
+        script:
+          - source /opt/qt55/bin/qt55-env.sh
+          - /opt/qt55/bin/qmake -r limereport.pro
+          - make
+          - make check          
 
-script:
-  - qmake -r limereport.pro
-  - make
-  - make check
+      - env: Qt5.5.1_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt551-trusty'
+            packages:
+              - qt55base
+              - qt55script
+              - qt55tools
+            
+        script:
+          - source /opt/qt55/bin/qt55-env.sh
+          - /opt/qt55/bin/qmake -r limereport.pro
+          - make
+          - make check  
+          
+      - env: Qt5.6.3_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt563-trusty'
+            packages:
+              - qt56base
+              - qt56script
+              - qt56tools
+            
+        script:
+          - source /opt/qt56/bin/qt56-env.sh
+          - /opt/qt56/bin/qmake -r limereport.pro
+          - make
+          - make check
 
+      - env: Qt5.6.3_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt563-trusty'
+            packages:
+              - qt56base
+              - qt56script
+              - qt56tools
+            
+        script:
+          - source /opt/qt56/bin/qt56-env.sh
+          - /opt/qt56/bin/qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.7.1_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt571-trusty'
+            packages:
+              - qt57base
+              - qt57script
+              - qt57tools
+            
+        script:
+          - source /opt/qt57/bin/qt57-env.sh
+          - /opt/qt57/bin/qmake -r limereport.pro
+          - make
+          - make check
+
+      - env: Qt5.7.1_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt571-trusty'
+            packages:
+              - qt57base
+              - qt57script
+              - qt57tools
+            
+        script:
+          - source /opt/qt57/bin/qt57-env.sh
+          - /opt/qt57/bin/qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.8.0_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt58-trusty'
+            packages:
+              - qt58base
+              - qt58script
+              - qt58tools
+            
+        script:
+          - source /opt/qt58/bin/qt58-env.sh
+          - /opt/qt58/bin/qmake -r limereport.pro
+          - make
+          - make check
+
+      - env: Qt5.8.0_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt58-trusty'
+            packages:
+              - qt58base
+              - qt58script
+              - qt58tools
+            
+        script:
+          - source /opt/qt58/bin/qt58-env.sh
+          - /opt/qt58/bin/qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.9.7_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt597-trusty'
+            packages:
+              - qt59base
+              - qt59script
+              - qt59tools
+            
+        script:
+          - source /opt/qt59/bin/qt59-env.sh
+          - /opt/qt59/bin/qmake -r limereport.pro
+          - make
+          - make check
+
+      - env: Qt5.9.7_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt597-trusty'
+            packages:
+              - qt59base
+              - qt59script
+              - qt59tools
+            
+        script:
+          - source /opt/qt59/bin/qt59-env.sh
+          - /opt/qt59/bin/qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.10.1_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt-5.10.1-trusty'
+            packages:
+              - qt510base
+              - qt510script
+              - qt510tools
+            
+        script:
+          - source /opt/qt510/bin/qt510-env.sh
+          - /opt/qt510/bin/qmake -r limereport.pro
+          - make
+          - make check
+
+      - env: Qt5.10.1_Ubuntu_14.04
+        os: linux
+        dist: trusty
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt-5.10.1-trusty'
+            packages:
+              - qt510base
+              - qt510script
+              - qt510tools
+            
+        script:
+          - source /opt/qt510/bin/qt510-env.sh
+          - /opt/qt510/bin/qmake -r limereport.pro
+          - make
+          - make check
+
+      - env: Qt5.11.3_Ubuntu_18.04
+        os: linux
+        dist: bionic
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt-5.11.3-bionic'
+            packages:
+              - qt511base
+              - qt511script
+              - qt511tools
+              - mesa-common-dev
+              - libgl1-mesa-dev
+            
+        script:
+          - source /opt/qt511/bin/qt511-env.sh
+          - /opt/qt511/bin/qmake -r limereport.pro
+          - make
+          - make check
+
+      - env: Qt5.11.3_Ubuntu_18.04
+        os: linux
+        dist: bionic
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt-5.11.3-bionic'
+            packages:
+              - qt511base
+              - qt511script
+              - qt511tools
+              - mesa-common-dev
+              - libgl1-mesa-dev
+              
+        script:
+          - source /opt/qt511/bin/qt511-env.sh
+          - /opt/qt511/bin/qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.12.3_Ubuntu_18.04
+        os: linux
+        dist: bionic
+        language: cpp
+        compiler: gcc
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
+            packages:
+              - qt512base
+              - qt512script
+              - qt512tools
+              - mesa-common-dev
+              - libgl1-mesa-dev
+              
+        script:
+          - source /opt/qt512/bin/qt512-env.sh
+          - /opt/qt512/bin/qmake -r limereport.pro
+          - make
+          - make check
+          
+      - env: Qt5.12.3_Ubuntu_18.04
+        os: linux
+        dist: bionic
+        language: cpp
+        compiler: clang
+        cache: ccache
+        addons:
+          apt:
+            sources:
+              - sourceline: 'ppa:beineri/opt-qt-5.12.3-bionic'
+            packages:
+              - qt512base
+              - qt512script
+              - qt512tools
+              - mesa-common-dev
+              - libgl1-mesa-dev
+              
+        script:
+          - source /opt/qt512/bin/qt512-env.sh
+          - /opt/qt512/bin/qmake -r limereport.pro
+          - make
+          - make check          
+          
 notifications:
   email: false
-

--- a/limereport.pro
+++ b/limereport.pro
@@ -16,8 +16,13 @@ SUBDIRS += \
         limereport \
         demo_r1 \
         demo_r2 \
-        console \
         designer
+
+greaterThan(QT_MAJOR_VERSION, 4){
+greaterThan(QT_MINOR_VERSION, 1){
+        SUBDIRS += console
+    }
+}
 
 !contains(CONFIG, embedded_designer){
 !contains(CONFIG, static_build){

--- a/limereport/exporters/lrpdfexporter.h
+++ b/limereport/exporters/lrpdfexporter.h
@@ -11,7 +11,7 @@ class PDFExporter : public QObject, public ReportExporterInterface
 {
     Q_OBJECT
 public:
-    explicit PDFExporter(ReportEnginePrivate *parent = nullptr);
+    explicit PDFExporter(ReportEnginePrivate *parent = NULL);
     // ReportExporterInterface interface
     bool exportPages(ReportPages pages, const QString &fileName, const QMap<QString, QVariant> &params);
     QString exporterName()

--- a/limereport/items/lrimageitemeditor.h
+++ b/limereport/items/lrimageitemeditor.h
@@ -16,7 +16,7 @@ class ImageItemEditor : public QWidget
     Q_OBJECT
 
 public:
-    explicit ImageItemEditor(LimeReport::ImageItem* item, QWidget *parent = nullptr);
+    explicit ImageItemEditor(LimeReport::ImageItem* item, QWidget *parent = NULL);
     ~ImageItemEditor();
 private:
     void updateImage();

--- a/limereport/lrbanddesignintf.cpp
+++ b/limereport/lrbanddesignintf.cpp
@@ -176,7 +176,7 @@ BandDesignIntf::BandDesignIntf(BandsType bandType, const QString &xmlTypeName, Q
         if (parentItem) setWidth(parentItem->width());
     }
 
-    setBackgroundMode(BGMode::TransparentMode);
+    setBackgroundMode(BaseDesignIntf::TransparentMode);
     setFillTransparentInDesignMode(false);
     setHeight(100);
     setFixedPos(true);

--- a/limereport/lrreportdesignwidget.h
+++ b/limereport/lrreportdesignwidget.h
@@ -82,12 +82,12 @@ private:
 
 class PageView: public QGraphicsView{
 public:
-    PageView(QWidget *parent = nullptr): QGraphicsView(parent),
+    PageView(QWidget *parent = NULL): QGraphicsView(parent),
         m_horizontalRuller(0), m_verticalRuller(0)
     {
         setViewportMargins(20,20,0,0);
     }
-    PageView(QGraphicsScene *scene, QWidget *parent = nullptr):
+    PageView(QGraphicsScene *scene, QWidget *parent = NULL):
         QGraphicsView(scene, parent),
         m_horizontalRuller(0), m_verticalRuller(0)
     {

--- a/limereport/lrreportengine.cpp
+++ b/limereport/lrreportengine.cpp
@@ -299,7 +299,7 @@ void ReportEnginePrivate::printReport(ItemsReaderIntf::Ptr reader, QPrinter& pri
 void ReportEnginePrivate::printReport(ReportPages pages, QPrinter &printer)
 {
     int currenPage = 1;
-    QMap<QString, QSharedPointer<PrintProcessor>> printProcessors;
+    QMap<QString, QSharedPointer<PrintProcessor> > printProcessors;
     printProcessors.insert("default",QSharedPointer<PrintProcessor>(new PrintProcessor(&printer)));
     foreach(PageItemDesignIntf::Ptr page, pages){
         if (
@@ -320,7 +320,7 @@ void ReportEnginePrivate::printReport(ReportPages pages, QMap<QString, QPrinter*
 {
     if (printers.values().isEmpty()) return;
     int currenPage = 1;
-    QMap<QString, QSharedPointer<PrintProcessor>> printProcessors;
+    QMap<QString, QSharedPointer<PrintProcessor> > printProcessors;
     for (int i = 0; i < printers.keys().count(); ++i) {
         printProcessors.insert(printers.keys()[i],QSharedPointer<PrintProcessor>(new PrintProcessor(printers[printers.keys()[i]])));
     }

--- a/limereport/lrscriptenginemanager.cpp
+++ b/limereport/lrscriptenginemanager.cpp
@@ -1930,7 +1930,7 @@ bool DatasourceFunctions::isEOF(const QString &datasourceName)
 bool DatasourceFunctions::invalidate(const QString& datasourceName)
 {
     if (m_dataManager && m_dataManager->dataSource(datasourceName)){
-        m_dataManager->dataSourceHolder(datasourceName)->invalidate(IDataSource::DatasourceMode::RENDER_MODE);
+        m_dataManager->dataSourceHolder(datasourceName)->invalidate(IDataSource::RENDER_MODE);
         return true;
     }
     return false;

--- a/limereport/objectinspector/lrobjectpropitem.h
+++ b/limereport/objectinspector/lrobjectpropitem.h
@@ -99,7 +99,7 @@ namespace LimeReport{
 #endif
     private:
         bool m_valid;
-        void invalidate(){m_object=0; m_objects=0; m_valid = false; m_name = ""; m_value=QVariant(), m_isClass=false;}
+        void invalidate(){m_object=0; m_objects=0; m_valid = false; m_name = ""; m_value=QVariant(); m_isClass=false;}
 
     protected:
         void beginChangeValue(){ m_changingValue = true; }
@@ -140,4 +140,7 @@ namespace LimeReport{
     };
 
 }
+
+Q_DECLARE_METATYPE(LimeReport::ObjectPropItem*)
+
 #endif // LROBJECTPROPITEM_H


### PR DESCRIPTION
I updated the travis script to test all available Qt versions and the last Qt4 release. 
Versions below 5.6 now compile.
Qt4.8 still has one error, there is a protected signal being emited outside the object in 
https://github.com/fralx/LimeReport/blob/3eb98d791475f76167462431ffb03c578ee163e2/limereport/lrpagedesignintf.cpp#L2139
but I don't know how to properly fix that (signals changed to public in Qt5).

The last travis build can be seen here: https://travis-ci.org/darktorres/LimeReport/builds/570298359