### PR TITLE
Fix Lime Report Designer's Title Bar not showing Report's Name after …

### DIFF
--- a/limereport/lrreportdesignwindow.cpp
+++ b/limereport/lrreportdesignwindow.cpp
@@ -1126,6 +1126,7 @@ void ReportDesignWindow::slotSaveReport()
     QString filename = m_reportDesignWidget->reportFileName();
     m_lblReportName->setText(filename);
     if(!filename.isEmpty()) addRecentFile(filename);
+    setWindowTitle(m_reportDesignWidget->report()->reportName() + " - Lime Report Designer");
 }
 
 void ReportDesignWindow::slotSaveReportAs()
@@ -1137,6 +1138,7 @@ void ReportDesignWindow::slotSaveReportAs()
         m_reportDesignWidget->saveToFile(fileName);
         m_lblReportName->setText(m_reportDesignWidget->reportFileName());
         addRecentFile(fileName);
+        setWindowTitle(m_reportDesignWidget->report()->reportName() + " - Lime Report Designer");
     }
 }
 

--- a/limereport/lrreportengine.cpp
+++ b/limereport/lrreportengine.cpp
@@ -876,6 +876,7 @@ bool ReportEnginePrivate::saveToFile(const QString &fileName)
         }
     }
     dropChanges();
+    this->setReportName(fi.baseName());
     return saved;
 }
 


### PR DESCRIPTION
@fralx I noticed when a new report was saved or an already opened one was saved with another name the title bar of the Designer does not showed that new name. I fix that issue here. :)