### PR TITLE
#323: Replace " " with "_" when saving translations.

### DIFF
--- a/limereport/serializators/lrxmlwriter.cpp
+++ b/limereport/serializators/lrxmlwriter.cpp
@@ -223,7 +223,7 @@ void XMLWriter::saveTranslation(QString propertyName, QObject* item, QDomElement
         translationsNode.setAttribute("Type","Translation");
         Translations* translations = translationsContainer->translations();
         foreach(QLocale::Language language, translations->keys()){
-            QDomElement languageNode = m_doc->createElement(QLocale::languageToString(language));
+            QDomElement languageNode = m_doc->createElement(QLocale::languageToString(language).replace(' ', '_'));
             languageNode.setAttribute("Value",QString::number(language));
             translationsNode.appendChild(languageNode);
             ReportTranslation* curTranslation = translations->value(language);


### PR DESCRIPTION
See #323.
Reports containing translations for a language like "Norwergian Nynorsk" (name contains spaces) can't be loaded properly.
