### PR TITLE
Refactor min and max values

### DIFF
--- a/limereport/items/charts/lrhorizontalbarchart.cpp
+++ b/limereport/items/charts/lrhorizontalbarchart.cpp
@@ -4,11 +4,15 @@ namespace LimeReport{
 
 void HorizontalBarChart::paintChart(QPainter *painter, QRectF chartRect)
 {
+    updateMinAndMaxValues();
+
+    const qreal valuesVMargin = this->valuesVMargin(painter);
+
     QRectF calcRect = verticalLabelsRect(painter, chartRect.adjusted(
                                               hPadding(chartRect),
                                               vPadding(chartRect) * 2,
                                               -(chartRect.width() * 0.9),
-                                              -(vPadding(chartRect) * 2 + valuesVMargin(painter))
+                                              -(vPadding(chartRect) * 2 + valuesVMargin)
                                               ));
 
     qreal barsShift = calcRect.width();

--- a/limereport/items/charts/lrlineschart.cpp
+++ b/limereport/items/charts/lrlineschart.cpp
@@ -4,10 +4,15 @@ namespace LimeReport {
 
 void LinesChart::paintChart(QPainter *painter, QRectF chartRect)
 {
+    updateMinAndMaxValues();
+
+    const qreal valuesHMargin = this->valuesHMargin(painter);
+    const qreal valuesVMargin = this->valuesVMargin(painter);
+
     QRectF calcRect = horizontalLabelsRect(
         painter,
         chartRect.adjusted(
-            hPadding(chartRect) * 2 + valuesHMargin(painter),
+            hPadding(chartRect) * 2 + valuesHMargin,
             chartRect.height() - (painter->fontMetrics().height() + vPadding(chartRect)*2),
             -(hPadding(chartRect) * 2),
             -vPadding(chartRect)
@@ -18,7 +23,7 @@ void LinesChart::paintChart(QPainter *painter, QRectF chartRect)
         painter,
         chartRect.adjusted(
             hPadding(chartRect),
-            vPadding(chartRect) + valuesVMargin(painter),
+            vPadding(chartRect) + valuesVMargin,
             -hPadding(chartRect),
             -(vPadding(chartRect) + barsShift)
         )
@@ -26,8 +31,8 @@ void LinesChart::paintChart(QPainter *painter, QRectF chartRect)
     paintSerialLines(
         painter,
         chartRect.adjusted(
-            hPadding(chartRect) * 2 + valuesHMargin(painter),
-            vPadding(chartRect) + valuesVMargin(painter),
+            hPadding(chartRect) * 2 + valuesHMargin,
+            vPadding(chartRect) + valuesVMargin,
             -(hPadding(chartRect) * 2),
             -(vPadding(chartRect)+barsShift)
         )

--- a/limereport/items/charts/lrverticalbarchart.cpp
+++ b/limereport/items/charts/lrverticalbarchart.cpp
@@ -4,10 +4,15 @@ namespace LimeReport{
 
 void VerticalBarChart::paintChart(QPainter *painter, QRectF chartRect)
 {
+    updateMinAndMaxValues();
+
+    const qreal valuesHMargin = this->valuesHMargin(painter);
+    const qreal valuesVMargin = this->valuesVMargin(painter);
+
     QRectF calcRect = horizontalLabelsRect(
         painter,
         chartRect.adjusted(
-            hPadding(chartRect) * 2 + valuesHMargin(painter),
+            hPadding(chartRect) * 2 + valuesHMargin,
             chartRect.height() - (painter->fontMetrics().height() + vPadding(chartRect) * 2),
             -(hPadding(chartRect) * 2),
             -vPadding(chartRect)
@@ -18,7 +23,7 @@ void VerticalBarChart::paintChart(QPainter *painter, QRectF chartRect)
         painter,
         chartRect.adjusted(
             hPadding(chartRect),
-            vPadding(chartRect) + valuesVMargin(painter),
+            vPadding(chartRect) + valuesVMargin,
             -hPadding(chartRect),
             -(vPadding(chartRect) + barsShift)
         )
@@ -26,8 +31,8 @@ void VerticalBarChart::paintChart(QPainter *painter, QRectF chartRect)
     paintVerticalBars(
         painter,
         chartRect.adjusted(
-            hPadding(chartRect) * 2 + valuesHMargin(painter),
-            vPadding(chartRect) + valuesVMargin(painter),
+            hPadding(chartRect) * 2 + valuesHMargin,
+            vPadding(chartRect) + valuesVMargin,
             -hPadding(chartRect) * 2,
             -(vPadding(chartRect) + barsShift)
         )
@@ -35,8 +40,8 @@ void VerticalBarChart::paintChart(QPainter *painter, QRectF chartRect)
     paintSerialLines(
         painter,
         chartRect.adjusted(
-            hPadding(chartRect) * 2 + valuesHMargin(painter),
-            vPadding(chartRect) + valuesVMargin(painter),
+            hPadding(chartRect) * 2 + valuesHMargin,
+            vPadding(chartRect) + valuesVMargin,
             -hPadding(chartRect) * 2,
             -(vPadding(chartRect) + barsShift)
         )

--- a/limereport/items/lrchartitem.cpp
+++ b/limereport/items/lrchartitem.cpp
@@ -516,26 +516,29 @@ AbstractSeriesChart::AbstractSeriesChart(ChartItem *chartItem)
 
 qreal AbstractSeriesChart::maxValue()
 {
-    if (m_chartItem->itemMode() == DesignMode) return 40;
-    qreal maxValue = 0;
-    foreach(SeriesItem* series, m_chartItem->series()){
-        foreach(qreal value, series->data()->values()){
-            if (value>maxValue) maxValue=value;
-        }
-    }
-    return maxValue;
+    return m_maxValue;
 }
 
 qreal AbstractSeriesChart::minValue()
 {
-    if (m_chartItem->itemMode() == DesignMode) return 0;
-    qreal minValue = 0;
+    return m_minValue;
+}
+
+void AbstractSeriesChart::updateMinAndMaxValues()
+{
+    if (m_chartItem->itemMode() == DesignMode) {
+        m_maxValue = 40;
+        m_minValue = 0;
+        return;
+    }
+    m_minValue = 0;
+    m_maxValue = 0;
     foreach(SeriesItem* series, m_chartItem->series()){
         foreach(qreal value, series->data()->values()){
-            if (value<minValue) minValue=value;
+            if (value<m_minValue) m_minValue=value;
+            if (value>m_maxValue) m_maxValue=value;
         }
     }
-    return minValue;
 }
 
 qreal AbstractSeriesChart::hPadding(QRectF chartRect)
@@ -679,11 +682,13 @@ void AbstractSeriesChart::paintVerticalGrid(QPainter *painter, QRectF gridRect)
     painter->setRenderHint(QPainter::Antialiasing,false);
     qreal vStep = gridRect.height() / 4;
 
+    const qreal valuesHMargin = this->valuesHMargin(painter);
+
     for (int i=0;i<5;i++){
         painter->drawText(QRectF(gridRect.bottomLeft()-QPointF(0,vStep*i+painter->fontMetrics().height()),
-                                 QSizeF(valuesHMargin(painter),painter->fontMetrics().height())),
+                                 QSizeF(valuesHMargin,painter->fontMetrics().height())),
                           QString::number(minValue()+i*delta/4));
-        painter->drawLine(gridRect.bottomLeft()-QPointF(-valuesHMargin(painter),vStep*i),
+        painter->drawLine(gridRect.bottomLeft()-QPointF(-valuesHMargin,vStep*i),
                           gridRect.bottomRight()-QPointF(0,vStep*i));
     }
 

--- a/limereport/items/lrchartitem.h
+++ b/limereport/items/lrchartitem.h
@@ -85,6 +85,7 @@ public:
 protected:
     qreal maxValue();
     qreal minValue();
+    void updateMinAndMaxValues();
     int valuesCount();
     int seriesCount();
     bool verticalLabels(QPainter* painter, QRectF labelsRect);
@@ -103,6 +104,7 @@ protected:
     virtual QFont adaptValuesFont(qreal width, QFont font);
 
 private:
+    qreal m_minValue = 0, m_maxValue = 0;
     qreal m_designValues [9];
 };
 


### PR DESCRIPTION
As discussed in #349 by @7ymekk . 

Changes recalculate min and max values when painting chart, because they aren't changing during that process. Draw speedup is huge.