### PR TITLE
Added grid chart with x axis

### DIFF
--- a/limereport/items/charts/lrgridlineschart.cpp
+++ b/limereport/items/charts/lrgridlineschart.cpp
@@ -9,14 +9,18 @@ void GridLinesChart::paintChart(QPainter *painter, QRectF chartRect)
     const qreal vPadding = this->vPadding(chartRect);
 
     const qreal valuesVMargin = this->valuesVMargin(painter);
-    const qreal topOffset = painter->fontMetrics().height();
 
     QRectF gridRect = chartRect.adjusted(
         hPadding,
-        vPadding + valuesVMargin + topOffset,
+        vPadding + valuesVMargin * 2,
         -hPadding * 3,
-        -vPadding
+        -vPadding * 3
         );
+
+    if (!m_chartItem->horizontalAxisOnTop()) {
+        // If horizontal axis is on the bottom, move grid a little up
+        gridRect.adjust(0, -valuesVMargin, 0 , -valuesVMargin);
+    }
 
     // Adapt font for horizontal axis
     painter->setFont(adaptFont((gridRect.width() - this->valuesHMargin(painter)) / xAxisData().segmentCount() * 0.8,
@@ -25,23 +29,8 @@ void GridLinesChart::paintChart(QPainter *painter, QRectF chartRect)
 
     const qreal valuesHMargin = this->valuesHMargin(painter);
 
-    QRectF calcRect = horizontalLabelsRect(
-        painter,
-        chartRect.adjusted(
-            hPadding * 2 + valuesHMargin,
-            chartRect.height() - (painter->fontMetrics().height() + vPadding*2),
-            -(hPadding * 2),
-            -vPadding
-            )
-        );
-    gridRect.adjust(0, 0, 0, -calcRect.height());
-
-    if (!m_chartItem->horizontalAxisOnTop()) {
-        // Draw labels above the grid
-        const qreal height = calcRect.height();
-        calcRect.setBottom(gridRect.top());
-        calcRect.setTop(calcRect.bottom() - height);
-    }
+    // Adjust vertical axis labels padding
+    gridRect.adjust(valuesHMargin * 0.2, 0, 0, 0);
 
     paintGrid(painter, gridRect);
 
@@ -49,7 +38,6 @@ void GridLinesChart::paintChart(QPainter *painter, QRectF chartRect)
         painter,
         gridRect.adjusted(hPadding + valuesHMargin, 0, 0, 0)
         );
-    paintHorizontalLabels(painter, calcRect);
 }
 
 void GridLinesChart::paintSerialLines(QPainter* painter, QRectF barsRect)

--- a/limereport/items/charts/lrgridlineschart.cpp
+++ b/limereport/items/charts/lrgridlineschart.cpp
@@ -5,11 +5,25 @@ void GridLinesChart::paintChart(QPainter *painter, QRectF chartRect)
 {
     updateMinAndMaxValues();
 
-    const qreal valuesHMargin = this->valuesHMargin(painter);
-    const qreal valuesVMargin = this->valuesVMargin(painter);
-
     const qreal hPadding = this->hPadding(chartRect);
     const qreal vPadding = this->vPadding(chartRect);
+
+    const qreal valuesVMargin = this->valuesVMargin(painter);
+    const qreal topOffset = painter->fontMetrics().height();
+
+    QRectF gridRect = chartRect.adjusted(
+        hPadding,
+        vPadding + valuesVMargin + topOffset,
+        -hPadding * 3,
+        -vPadding
+        );
+
+    // Adapt font for horizontal axis
+    painter->setFont(adaptFont((gridRect.width() - this->valuesHMargin(painter)) / xAxisData().segmentCount() * 0.8,
+                               painter->font(),
+                               xAxisData()));
+
+    const qreal valuesHMargin = this->valuesHMargin(painter);
 
     QRectF calcRect = horizontalLabelsRect(
         painter,
@@ -20,14 +34,7 @@ void GridLinesChart::paintChart(QPainter *painter, QRectF chartRect)
             -vPadding
             )
         );
-    const qreal barsShift = calcRect.height();
-    const qreal topOffset = painter->fontMetrics().height();
-    QRectF gridRect = chartRect.adjusted(
-        hPadding,
-        vPadding + valuesVMargin + topOffset,
-        -hPadding * 3,
-        -(vPadding + barsShift)
-        );
+    gridRect.adjust(0, 0, 0, -calcRect.height());
 
     if (!m_chartItem->horizontalAxisOnTop()) {
         // Draw labels above the grid

--- a/limereport/items/charts/lrgridlineschart.cpp
+++ b/limereport/items/charts/lrgridlineschart.cpp
@@ -21,13 +21,20 @@ void GridLinesChart::paintChart(QPainter *painter, QRectF chartRect)
             )
         );
     const qreal barsShift = calcRect.height();
-    const qreal topOffset = painter->fontMetrics().height() * (m_chartItem->horizontalAxisOnTop() ? 1 : -1);
-    const QRectF gridRect = chartRect.adjusted(
+    const qreal topOffset = painter->fontMetrics().height();
+    QRectF gridRect = chartRect.adjusted(
         hPadding,
         vPadding + valuesVMargin + topOffset,
         -hPadding * 3,
         -(vPadding + barsShift)
         );
+
+    if (!m_chartItem->horizontalAxisOnTop()) {
+        // Draw labels above the grid
+        const qreal height = calcRect.height();
+        calcRect.setBottom(gridRect.top());
+        calcRect.setTop(calcRect.bottom() - height);
+    }
 
     paintGrid(painter, gridRect);
 

--- a/limereport/items/charts/lrgridlineschart.cpp
+++ b/limereport/items/charts/lrgridlineschart.cpp
@@ -1,0 +1,110 @@
+#include "lrgridlineschart.h"
+
+namespace LimeReport {
+void GridLinesChart::paintChart(QPainter *painter, QRectF chartRect)
+{
+    updateMinAndMaxValues();
+
+    const qreal valuesHMargin = this->valuesHMargin(painter);
+    const qreal valuesVMargin = this->valuesVMargin(painter);
+
+    const qreal hPadding = this->hPadding(chartRect);
+    const qreal vPadding = this->vPadding(chartRect);
+
+    QRectF calcRect = horizontalLabelsRect(
+        painter,
+        chartRect.adjusted(
+            hPadding * 2 + valuesHMargin,
+            chartRect.height() - (painter->fontMetrics().height() + vPadding*2),
+            -(hPadding * 2),
+            -vPadding
+            )
+        );
+    const qreal barsShift = calcRect.height();
+    const qreal topOffset = painter->fontMetrics().height() * (m_chartItem->horizontalAxisOnTop() ? 1 : -1);
+    const QRectF gridRect = chartRect.adjusted(
+        hPadding,
+        vPadding + valuesVMargin + topOffset,
+        -hPadding * 3,
+        -(vPadding + barsShift)
+        );
+
+    paintGrid(painter, gridRect);
+
+    paintSerialLines(
+        painter,
+        gridRect.adjusted(hPadding + valuesHMargin, 0, 0, 0)
+        );
+    paintHorizontalLabels(painter, calcRect);
+}
+
+void GridLinesChart::paintSerialLines(QPainter* painter, QRectF barsRect)
+{
+    if (valuesCount() == 0) return;
+
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing,true);
+
+    const AxisData &yAxisData = this->yAxisData();
+    const qreal delta = yAxisData.delta();
+
+    if (m_chartItem->itemMode() == DesignMode){
+        const qreal hStep = barsRect.width() / valuesCount();
+        const qreal vStep = barsRect.height() / delta;
+        const qreal topShift = (delta - (maxValue() - minValue())) * vStep + barsRect.top();
+        drawDesignMode(painter, hStep, vStep, topShift, barsRect);
+        painter->restore();
+        return;
+    }
+
+    const AxisData &xAxisData = this->xAxisData();
+    const qreal hStep = barsRect.width() / (xAxisData.rangeMax() - xAxisData.rangeMin());
+
+    qreal leftMargin = 0;
+    const qreal topMargin = barsRect.top();
+
+    for (SeriesItem* series : m_chartItem->series()) {
+        QPen pen(series->color());
+        pen.setWidth(m_chartItem->seriesLineWidth());
+        painter->setPen(pen);
+
+        const QList<qreal> &xAxisValues = series->data()->xAxisValues();
+        const QList<qreal> &values = series->data()->values();
+        const int xAxisValuesSize = xAxisValues.size();
+        qreal lastXPos = 0;
+        qreal lastYPos = 0;
+        if (!values.isEmpty()) {
+            // Calculate first point position on plot before loop
+            lastYPos = calculatePos(yAxisData, values.first(), barsRect.height());
+        }
+        if (xAxisValues.isEmpty()) {
+            leftMargin = barsRect.left();
+        } else {
+            leftMargin = barsRect.left();
+            lastXPos = calculatePos(xAxisData, xAxisValues.first(), barsRect.width());
+        }
+        for (int i = 0; i < values.count() - 1; ++i ) {
+            const qreal startY = lastYPos;
+            const qreal endY = calculatePos(yAxisData, values.at(i+1), barsRect.height());
+            // Record last used Y position to only calculate new one
+            lastYPos = endY;
+
+            qreal startX = lastXPos;
+            qreal endX = 0;
+            if (i + 1 < xAxisValuesSize) {
+                endX = calculatePos(xAxisData, xAxisValues.at(i+1), barsRect.width());
+            } else {
+                endX = startX + hStep;
+            }
+            // Record last used X position to only calculate new one
+            lastXPos = endX;
+
+            QPoint startPoint = QPoint(startX + leftMargin, startY + topMargin);
+            QPoint endPoint = QPoint(endX + leftMargin, endY + topMargin);
+            drawSegment(painter, startPoint, endPoint, series->color());
+        }
+    }
+
+    painter->restore();
+}
+}

--- a/limereport/items/charts/lrgridlineschart.h
+++ b/limereport/items/charts/lrgridlineschart.h
@@ -1,0 +1,17 @@
+#ifndef GRIDLINESCHART_H
+#define GRIDLINESCHART_H
+
+#include "lrlineschart.h"
+
+namespace LimeReport {
+class GridLinesChart : public LinesChart{
+public:
+    GridLinesChart(ChartItem* chartItem):LinesChart(chartItem){}
+    void paintChart(QPainter *painter, QRectF chartRect);
+
+private:
+    void paintSerialLines(QPainter *painter, QRectF barsRect);
+};
+}
+
+#endif // GRIDLINESCHART_H

--- a/limereport/items/charts/lrhorizontalbarchart.cpp
+++ b/limereport/items/charts/lrhorizontalbarchart.cpp
@@ -20,7 +20,9 @@ void HorizontalBarChart::paintChart(QPainter *painter, QRectF chartRect)
     paintHorizontalGrid(painter, chartRect.adjusted(
                                      hPadding(chartRect) + barsShift,
                                      vPadding(chartRect),
-                                     -(hPadding(chartRect)),-vPadding(chartRect)));
+                                     -(hPadding(chartRect)),
+                                     -vPadding(chartRect)));
+
     paintHorizontalBars(painter, chartRect.adjusted(
                                      hPadding(chartRect) + barsShift,
                                      vPadding(chartRect) * 2,
@@ -36,25 +38,33 @@ void HorizontalBarChart::paintHorizontalBars(QPainter *painter, QRectF barsRect)
 
     painter->save();
     painter->setRenderHint(QPainter::Antialiasing,false);
+
     const AxisData &yAxisData = this->yAxisData();
     const qreal delta = yAxisData.delta();
 
-    qreal vStep = (barsRect.height()-painter->fontMetrics().height()) / valuesCount() / seriesCount();
+    const qreal verticalOffset = painter->fontMetrics().height();
+    qreal vStep = (barsRect.height() - verticalOffset) / valuesCount() / seriesCount();
     qreal hStep = (barsRect.width()-painter->fontMetrics().boundingRect(QString::number(maxValue())).width()) / delta;
 
     if (!m_chartItem->series().isEmpty() && (m_chartItem->itemMode() != DesignMode)){
-        int curSeries = 0;
+        qreal curVOffset = barsRect.top();
+        if (m_chartItem->horizontalAxisOnTop()) {
+            curVOffset += verticalOffset;
+        }
         foreach (SeriesItem* series, m_chartItem->series()) {
-            qreal curVOffset = curSeries*vStep+barsRect.top();
             painter->setBrush(series->color());
+            qreal y = curVOffset;
             foreach (qreal value, series->data()->values()) {
-                painter->drawRect(QRectF((-minValue()*hStep)+barsRect.left(), curVOffset, value*hStep, vStep));
-                curVOffset+=vStep*seriesCount();
+                painter->drawRect(QRectF((-minValue()*hStep)+barsRect.left(), y, value*hStep, vStep));
+                y+=vStep*seriesCount();
             }
-            curSeries++;
+            curVOffset += vStep;
         }
     } else {
         qreal curVOffset = barsRect.top();
+        if (m_chartItem->horizontalAxisOnTop()) {
+            curVOffset += verticalOffset;
+        }
         int curColor = 0;
         for (int i=0; i<9; ++i){
             if (curColor==3) curColor=0;

--- a/limereport/items/charts/lrlineschart.cpp
+++ b/limereport/items/charts/lrlineschart.cpp
@@ -70,12 +70,7 @@ void LinesChart::drawDesignMode(QPainter* painter, qreal hStep, qreal vStep, qre
 
 qreal LinesChart::calculatePos(const AxisData &data, qreal value, qreal rectSize) const
 {
-    if (data.reverseDirection() && data.rangeMin() >= 0) {
-        // Not flipping for minimum less than 0 because lower number is at the bottom.
-        return (1 - (data.rangeMax() - value) / data.delta()) * rectSize;
-    } else {
-        return (data.rangeMax() - value) / data.delta() * rectSize;
-    }
+    return (data.rangeMax() - value) / data.delta() * rectSize;
 }
 
 void LinesChart::paintSeries(QPainter *painter, SeriesItem *series, QRectF barsRect)

--- a/limereport/items/charts/lrlineschart.cpp
+++ b/limereport/items/charts/lrlineschart.cpp
@@ -81,8 +81,9 @@ qreal LinesChart::calculatePos(const AxisData &data, qreal value, qreal rectSize
 void LinesChart::paintSeries(QPainter *painter, SeriesItem *series, QRectF barsRect)
 {
     const AxisData &yAxisData = this->yAxisData();
+    const AxisData &xAxisData = this->xAxisData();
 
-    const qreal xAxisDiff = std::max(1.0, maxXValue() - minXValue());
+    const qreal xAxisDiff = std::max(1.0, xAxisData.maxValue() - xAxisData.minValue());
     const qreal hStep = barsRect.width() / xAxisDiff;
     const qreal topMargin = barsRect.top();
 

--- a/limereport/items/charts/lrlineschart.cpp
+++ b/limereport/items/charts/lrlineschart.cpp
@@ -68,17 +68,22 @@ void LinesChart::drawDesignMode(QPainter* painter, qreal hStep, qreal vStep, qre
     }
 }
 
-qreal LinesChart::calculateValueYPos(qreal, qreal max, qreal value, qreal delta, qreal height)
+qreal LinesChart::calculatePos(const AxisData &data, qreal value, qreal rectSize) const
 {
-    return (max - value) / delta * height;
+    if (data.reverseDirection() && data.rangeMin() >= 0) {
+        // Not flipping for minimum less than 0 because lower number is at the bottom.
+        return (1 - (data.rangeMax() - value) / data.delta()) * rectSize;
+    } else {
+        return (data.rangeMax() - value) / data.delta() * rectSize;
+    }
 }
 
 void LinesChart::paintSeries(QPainter *painter, SeriesItem *series, QRectF barsRect)
 {
     const AxisData &yAxisData = this->yAxisData();
-    const qreal delta = yAxisData.delta();
 
-    const qreal hStep = barsRect.width() / valuesCount();
+    const qreal xAxisDiff = std::max(1.0, maxXValue() - minXValue());
+    const qreal hStep = barsRect.width() / xAxisDiff;
     const qreal topMargin = barsRect.top();
 
     QPen pen(series->color());
@@ -91,11 +96,11 @@ void LinesChart::paintSeries(QPainter *painter, SeriesItem *series, QRectF barsR
     qreal lastXValue = barsRect.left() + hStep/2;
     if (!values.isEmpty()) {
         // Calculate first point position on plot before loop
-        lastYValue = calculateValueYPos(yAxisData.rangeMin(), yAxisData.rangeMax(), values.first(), delta, barsRect.height());
+        lastYValue = calculatePos(yAxisData, values.first(), barsRect.height());
     }
     for (int i = 0; i < values.count()-1; ++i ){
         const qreal startY = lastYValue;
-        const qreal endY = calculateValueYPos(yAxisData.rangeMin(), yAxisData.rangeMax(), values.at(i+1), delta, barsRect.height());
+        const qreal endY = calculatePos(yAxisData, values.at(i+1), barsRect.height());
         // Record last used Y position to only calculate new one
         lastYValue = endY;
 

--- a/limereport/items/charts/lrlineschart.h
+++ b/limereport/items/charts/lrlineschart.h
@@ -10,7 +10,7 @@ public:
     void paintChart(QPainter *painter, QRectF chartRect);
 protected:
     void drawDesignMode(QPainter *painter, qreal hStep, qreal vStep, qreal topShift, QRectF barsRect);
-    qreal calculateValueYPos(qreal min, qreal max, qreal value, qreal delta, qreal height);
+    qreal calculatePos(const AxisData &data, qreal value, qreal rectSize) const;
     void paintSeries(QPainter *painter, SeriesItem *series, QRectF barsRect);
 
 private:

--- a/limereport/items/lrchartitem.cpp
+++ b/limereport/items/lrchartitem.cpp
@@ -633,7 +633,6 @@ void AbstractSeriesChart::updateMinAndMaxValues()
 
     m_yAxisData = AxisData(minYValue, maxYValue);
     m_xAxisData = AxisData(minXValue, maxXValue);
-    m_xAxisData.setReverseDirection(true);
 }
 
 qreal AbstractSeriesChart::hPadding(QRectF chartRect)
@@ -761,13 +760,18 @@ void AbstractSeriesChart::paintHorizontalGrid(QPainter *painter, QRectF gridRect
 
     painter->setFont(adaptValuesFont(hStep-4, painter->font()));
 
+    QPointF textPos;
+    if (m_chartItem->horizontalAxisOnTop()) {
+        textPos.setY(gridRect.top());
+    } else {
+        textPos.setY(gridRect.bottom() - painter->fontMetrics().height());
+    }
     for (int i = 0 ; i < lineCount ; i++ ) {
-        painter->drawText(QRectF(gridRect.left() + 4 + hStep * i, gridRect.bottom() - painter->fontMetrics().height(),
-                                 hStep, painter->fontMetrics().height()),
+        const qreal x = gridRect.left() + hStep * i;
+        textPos.setX(x + 4);
+        painter->drawText(QRectF(textPos, QSizeF(hStep, painter->fontMetrics().height())),
                           axisLabel(i, yAxisData));
-        painter->drawLine( gridRect.left()+hStep*i, gridRect.bottom(),
-                          gridRect.left()+hStep*i, gridRect.top());
-
+        painter->drawLine(x, gridRect.bottom(), x, gridRect.top());
     }
     painter->restore();
 }
@@ -790,7 +794,6 @@ void AbstractSeriesChart::paintVerticalGrid(QPainter *painter, QRectF gridRect)
     const QTextOption verticalTextOption(Qt::AlignRight);
     for (int i = 0 ; i < lineCount ; i++ ) {
         const qreal y = vStep * i;
-        // TODO_ES handle horizontalAxisOnTop
         painter->drawText(QRectF(gridRect.bottomLeft()-QPointF(textPositionOffset,y+halfFontHeight),
                                  QSizeF(valuesHMargin,fontHeight)),
                           axisLabel(i, yAxisData),
@@ -822,6 +825,8 @@ void AbstractSeriesChart::paintGrid(QPainter *painter, QRectF gridRect)
     const qreal valuesHMargin = this->valuesHMargin(painter);
     const qreal vStep = gridRect.height() / yAxisSegmentCount;
     const qreal hStep = (gridRect.width() - valuesHMargin - gridOffset) / xAxisSegmentCount;
+
+    painter->setFont(adaptValuesFont(hStep-4, painter->font()));
 
     // Vertical axis lines
     const QTextOption verticalTextOption(Qt::AlignRight);

--- a/limereport/items/lrchartitem.cpp
+++ b/limereport/items/lrchartitem.cpp
@@ -752,7 +752,6 @@ void AbstractSeriesChart::paintHorizontalGrid(QPainter *painter, QRectF gridRect
     painter->save();
 
     const AxisData &yAxisData = this->yAxisData();
-    const qreal delta = yAxisData.delta();
 
     const int segmentCount = yAxisData.segmentCount();
     const int lineCount = segmentCount + 1;
@@ -765,7 +764,7 @@ void AbstractSeriesChart::paintHorizontalGrid(QPainter *painter, QRectF gridRect
     for (int i = 0 ; i < lineCount ; i++ ) {
         painter->drawText(QRectF(gridRect.left() + 4 + hStep * i, gridRect.bottom() - painter->fontMetrics().height(),
                                  hStep, painter->fontMetrics().height()),
-                          QString::number(minValue() + i * delta / segmentCount));
+                          axisLabel(i, yAxisData));
         painter->drawLine( gridRect.left()+hStep*i, gridRect.bottom(),
                           gridRect.left()+hStep*i, gridRect.top());
 
@@ -791,6 +790,7 @@ void AbstractSeriesChart::paintVerticalGrid(QPainter *painter, QRectF gridRect)
     const QTextOption verticalTextOption(Qt::AlignRight);
     for (int i = 0 ; i < lineCount ; i++ ) {
         const qreal y = vStep * i;
+        // TODO_ES handle horizontalAxisOnTop
         painter->drawText(QRectF(gridRect.bottomLeft()-QPointF(textPositionOffset,y+halfFontHeight),
                                  QSizeF(valuesHMargin,fontHeight)),
                           axisLabel(i, yAxisData),
@@ -839,7 +839,7 @@ void AbstractSeriesChart::paintGrid(QPainter *painter, QRectF gridRect)
     for (int i = 0 ; i < xAxisLineCount ; i++) {
         const qreal x = gridRect.left() + hStep * i + valuesHMargin + gridOffset;
         const bool drawFullLine = i == 0 || i == xAxisSegmentCount;
-        const QString text = QString::number(xAxisData.rangeMin() + i * xAxisData.step());
+        const QString text = axisLabel(i, xAxisData);
 
         if (m_chartItem->horizontalAxisOnTop()) {
             painter->drawLine(x, gridRect.top() - gridOffset,

--- a/limereport/items/lrchartitem.cpp
+++ b/limereport/items/lrchartitem.cpp
@@ -971,13 +971,7 @@ QString AbstractSeriesChart::axisLabel(int i, const AxisData &axisData)
 {
     const qreal min = axisData.rangeMin();
     const qreal step = axisData.step();
-    qreal value = 0;
-    // For values below 0, axis is already reversed (value closer to 0 is higher)
-    if (axisData.reverseDirection() && min >= 0) {
-        value = min + (axisData.segmentCount() - i) * step;
-    } else {
-        value = min + i * step;
-    }
+    qreal value = min + i * step;
     if (std::floor(step) == step) {
         return QString::number(value);
     }

--- a/limereport/items/lrchartitem.cpp
+++ b/limereport/items/lrchartitem.cpp
@@ -143,7 +143,7 @@ ChartItem::ChartItem(QObject *owner, QGraphicsItem *parent)
       m_legendAlign(LegendAlignCenter), m_titleAlign(TitleAlignCenter),
       m_chartType(Pie), m_labelsField(""), m_isEmpty(true),
       m_showLegend(true), m_drawPoints(true), m_seriesLineWidth(4),
-      m_horizontalAxisOnTop(false), m_legendStyle(LegendPoints)
+      m_horizontalAxisOnTop(false)
 {
     m_labels<<"First"<<"Second"<<"Thrid";
     m_chart = new PieChart(this);
@@ -589,11 +589,11 @@ qreal AbstractSeriesChart::minValue()
 AxisData AbstractSeriesChart::yAxisData()
 {
     return m_yAxisData;
-qreal AbstractSeriesChart::minXValue()
-{
-    return m_chartItem->xAxisData()->minValue();
 }
 
+AxisData AbstractSeriesChart::xAxisData()
+{
+    return m_xAxisData;
 }
 
 void AbstractSeriesChart::updateMinAndMaxValues()
@@ -612,11 +612,8 @@ void AbstractSeriesChart::updateMinAndMaxValues()
                 maxYValue = std::max(maxYValue, value);
             }
             if (series->data()->xAxisValues().isEmpty()) {
-                // Grid plot starts from 0 on x axis so x range must be decresed by 1
-                const bool startingFromZero = m_chartItem->chartType() == ChartItem::GridLines;
-                const qreal valuesCount = this->valuesCount() - (startingFromZero ? 1 : 0);
                 minXValue = std::min(0.0, minXValue);
-                maxXValue = std::max(valuesCount, maxXValue);
+                maxXValue = std::max((qreal)valuesCount(), maxXValue);
             } else {
                 for (qreal value : series->data()->xAxisValues()){
                     minXValue = std::min(value, minXValue);
@@ -627,6 +624,8 @@ void AbstractSeriesChart::updateMinAndMaxValues()
     }
 
     m_yAxisData = AxisData(minYValue, maxYValue);
+    m_xAxisData = AxisData(minXValue, maxXValue);
+    m_xAxisData.setReverseDirection(true);
 }
 
 qreal AbstractSeriesChart::hPadding(QRectF chartRect)

--- a/limereport/items/lrchartitem.cpp
+++ b/limereport/items/lrchartitem.cpp
@@ -844,7 +844,7 @@ void AbstractSeriesChart::paintGrid(QPainter *painter, QRectF gridRect)
     const qreal valuesHMargin = this->valuesHMargin(painter);
     const qreal vStep = gridRect.height() / yAxisSegmentCount;
     const qreal hStep = (gridRect.width() - valuesHMargin - gridOffset.width()) / xAxisSegmentCount;
-    const qreal textPositionHOffset = valuesHMargin * 0.2;
+    const qreal textPositionHOffset = valuesHMargin * 0.1;
 
     // Vertical axis lines
     const QTextOption verticalTextOption(Qt::AlignRight);

--- a/limereport/items/lrchartitem.cpp
+++ b/limereport/items/lrchartitem.cpp
@@ -838,12 +838,15 @@ void AbstractSeriesChart::paintGrid(QPainter *painter, QRectF gridRect)
     const int yAxisSegmentCount = yAxisData.segmentCount();
     const int yAxisLineCount = yAxisSegmentCount + 1;
 
-    const qreal gridOffset = hPadding(gridRect);
     const int fontHeight = painter->fontMetrics().height();
     const int halfFontHeight = fontHeight / 2;
+    const QSizeF gridOffset = QSizeF(hPadding(gridRect), vPadding(gridRect));
     const qreal valuesHMargin = this->valuesHMargin(painter);
     const qreal vStep = gridRect.height() / yAxisSegmentCount;
-    const qreal hStep = (gridRect.width() - valuesHMargin - gridOffset) / xAxisSegmentCount;
+    const qreal hStep = (gridRect.width() - valuesHMargin - gridOffset.width()) / xAxisSegmentCount;
+    const qreal textPositionHOffset = valuesHMargin * 0.2;
+
+    // TODO_ES horizontal axis labels doesn't adapt font
 
     painter->setFont(adaptValuesFont(hStep-4, painter->font()));
 
@@ -853,37 +856,37 @@ void AbstractSeriesChart::paintGrid(QPainter *painter, QRectF gridRect)
         const qreal y = vStep * i;
         const bool drawFullLine = m_chartItem->gridChartLines() & ChartItem::HorizontalLine
                                   || i == 0 || i == xAxisSegmentCount;
-        painter->drawText(QRectF(gridRect.bottomLeft()-QPointF(halfFontHeight, y + halfFontHeight),
+        painter->drawText(QRectF(gridRect.bottomLeft()-QPointF(textPositionHOffset, y + halfFontHeight),
                                  QSizeF(valuesHMargin,fontHeight)),
                           axisLabel(i, yAxisData),
                           verticalTextOption);
 
         QPointF lineEndPos = gridRect.bottomRight() - QPointF(0, y);
         if (!drawFullLine) {
-            lineEndPos.setX(gridRect.left() + valuesHMargin + gridOffset);
+            lineEndPos.setX(gridRect.left() + valuesHMargin + gridOffset.width());
         }
         painter->drawLine(gridRect.bottomLeft() - QPointF(-valuesHMargin, y), lineEndPos);
     }
 
     // Horizontal axis lines
     for (int i = 0 ; i < xAxisLineCount ; i++) {
-        const qreal x = gridRect.left() + hStep * i + valuesHMargin + gridOffset;
+        const qreal x = gridRect.left() + hStep * i + valuesHMargin + gridOffset.width();
         const bool drawFullLine = m_chartItem->gridChartLines() & ChartItem::VerticalLine
                                   || i == 0 || i == xAxisSegmentCount;
         const QString text = axisLabel(i, xAxisData);
 
         if (m_chartItem->horizontalAxisOnTop()) {
-            painter->drawLine(x, gridRect.top() - gridOffset,
+            painter->drawLine(x, gridRect.top() - gridOffset.height(),
                               x, (drawFullLine ? gridRect.bottom() : gridRect.top()));
             painter->drawText(QRectF(x - painter->fontMetrics().width(text) / 2,
-                                     gridRect.top() - (fontHeight + gridOffset),
+                                     gridRect.top() - (fontHeight + gridOffset.height()),
                                      hStep, fontHeight),
                               text);
         } else {
-            painter->drawLine(x, gridRect.bottom() + gridOffset,
+            painter->drawLine(x, gridRect.bottom() + gridOffset.height(),
                               x, (drawFullLine ? gridRect.top() : gridRect.bottom()));
             painter->drawText(QRectF(x - painter->fontMetrics().width(text) / 2,
-                                     gridRect.bottom() + halfFontHeight + gridOffset,
+                                     gridRect.bottom() + halfFontHeight * 0 + gridOffset.height(),
                                      hStep, fontHeight),
                               text);
         }

--- a/limereport/items/lrchartitem.cpp
+++ b/limereport/items/lrchartitem.cpp
@@ -777,7 +777,7 @@ void AbstractSeriesChart::paintHorizontalGrid(QPainter *painter, QRectF gridRect
     painter->setRenderHint(QPainter::Antialiasing,false);
     qreal hStep = (gridRect.width() - painter->fontMetrics().boundingRect(QString::number(maxValue())).width()) / segmentCount;
 
-    painter->setFont(adaptValuesFont(hStep-4, painter->font()));
+    painter->setFont(adaptFont(hStep-4, painter->font(), yAxisData));
 
     QPointF textPos;
     if (m_chartItem->horizontalAxisOnTop()) {
@@ -845,10 +845,6 @@ void AbstractSeriesChart::paintGrid(QPainter *painter, QRectF gridRect)
     const qreal vStep = gridRect.height() / yAxisSegmentCount;
     const qreal hStep = (gridRect.width() - valuesHMargin - gridOffset.width()) / xAxisSegmentCount;
     const qreal textPositionHOffset = valuesHMargin * 0.2;
-
-    // TODO_ES horizontal axis labels doesn't adapt font
-
-    painter->setFont(adaptValuesFont(hStep-4, painter->font()));
 
     // Vertical axis lines
     const QTextOption verticalTextOption(Qt::AlignRight);
@@ -956,16 +952,19 @@ QFont AbstractSeriesChart::adaptLabelsFont(QRectF rect, QFont font)
     return tmpFont;
 }
 
-QFont AbstractSeriesChart::adaptValuesFont(qreal width, QFont font)
+QFont AbstractSeriesChart::adaptFont(qreal width, QFont font, const AxisData &axisData)
 {
-    QString strValue = QString::number(maxValue());
     QFont tmpFont = font;
+    const int axisLineCount = axisData.segmentCount() + 1;
     QScopedPointer<QFontMetricsF> fm(new QFontMetricsF(tmpFont));
-    qreal curWidth = fm->boundingRect(strValue).width();
-    while (curWidth > width && tmpFont.pixelSize() > 1){
-        tmpFont.setPixelSize(tmpFont.pixelSize() - 1);
-        fm.reset(new QFontMetricsF(tmpFont));
-        curWidth = fm->boundingRect(strValue).width();
+    for (int i = 0 ; i < axisLineCount ; i++) {
+        QString strValue = axisLabel(i, axisData);
+        qreal curWidth = fm->boundingRect(strValue).width();
+        while (curWidth > width && tmpFont.pixelSize() > 1){
+            tmpFont.setPixelSize(tmpFont.pixelSize() - 1);
+            fm.reset(new QFontMetricsF(tmpFont));
+            curWidth = fm->boundingRect(strValue).width();
+        }
     }
     return tmpFont;
 }

--- a/limereport/items/lrchartitem.h
+++ b/limereport/items/lrchartitem.h
@@ -145,6 +145,9 @@ class ChartItem : public LimeReport::ItemDesignIntf
     Q_PROPERTY(int seriesLineWidth READ seriesLineWidth WRITE setSeriesLineWidth)
     Q_PROPERTY(bool horizontalAxisOnTop READ horizontalAxisOnTop WRITE setHorizontalAxisOnTop)
     Q_PROPERTY(QString xAxisField READ xAxisField WRITE setXAxisField)
+
+    //girdChart
+    // TODO_ES add grid property for showing lines inside
     friend class AbstractChart;
 public:
 

--- a/limereport/items/lrchartitem.h
+++ b/limereport/items/lrchartitem.h
@@ -144,10 +144,11 @@ class ChartItem : public LimeReport::ItemDesignIntf
     Q_PROPERTY(bool drawPoints READ drawPoints WRITE setDrawPoints)
     Q_PROPERTY(int seriesLineWidth READ seriesLineWidth WRITE setSeriesLineWidth)
     Q_PROPERTY(bool horizontalAxisOnTop READ horizontalAxisOnTop WRITE setHorizontalAxisOnTop)
-    Q_PROPERTY(QString xAxisField READ xAxisField WRITE setXAxisField)
 
-    //girdChart
-    // TODO_ES add grid property for showing lines inside
+    //gridChart
+    Q_FLAGS(GridChartLines)
+    Q_PROPERTY(QString xAxisField READ xAxisField WRITE setXAxisField)
+    Q_PROPERTY(GridChartLines gridChartLines READ gridChartLines WRITE setGridChartLines)
     friend class AbstractChart;
 public:
 
@@ -155,15 +156,24 @@ public:
     enum LegendStyle{LegendPoints, LegendLines};
     enum TitleAlign{TitleAlignLeft, TitleAlignCenter, TitleAlignRight};
     enum ChartType{Pie, VerticalBar, HorizontalBar, Lines, GridLines};
+    enum LineType {
+        NoLine = 0,
+        HorizontalLine = 1,
+        VerticalLine = 2,
+        AllLines = 3
+    };
 #if QT_VERSION >= 0x050500
     Q_ENUM(LegendAlign)
     Q_ENUM(TitleAlign)
     Q_ENUM(ChartType)
+    Q_ENUM(LineType)
 #else
     Q_ENUMS(LegendAlign)
     Q_ENUMS(TitleAlign)
     Q_ENUMS(ChartType)
+    Q_ENUMS(LineType)
 #endif
+    Q_DECLARE_FLAGS(GridChartLines, LineType)
 
     ChartItem(QObject* owner, QGraphicsItem* parent);
     ~ChartItem();
@@ -213,6 +223,9 @@ public:
     bool horizontalAxisOnTop() const;
     void setHorizontalAxisOnTop(bool horizontalAxisOnTop);
 
+    GridChartLines gridChartLines() const;
+    void setGridChartLines(GridChartLines flags);
+
 protected:
     void paintChartTitle(QPainter* painter, QRectF titleRect);
     virtual BaseDesignIntf* createSameTypeItem(QObject *owner, QGraphicsItem *parent);
@@ -243,6 +256,7 @@ private:
     int m_seriesLineWidth;
     QString m_xAxisField;
     bool m_horizontalAxisOnTop;
+    GridChartLines m_gridChartLines;
 };
 } //namespace LimeReport
 #endif // LRCHARTITEM_H

--- a/limereport/items/lrchartitem.h
+++ b/limereport/items/lrchartitem.h
@@ -16,11 +16,12 @@ class SeriesItemData : public QObject{
     Q_OBJECT
 public:
     QList<qreal>& values(){ return m_values;}
+    QList<qreal>& xAxisValues(){ return m_xAxisValues;}
     QList<QString>& labels(){ return m_labels;}
     QList<QColor>& colors() { return m_colors;}
     void clear(){ m_values.clear(); m_labels.clear(); m_colors.clear(); }
 private:
-    QList<qreal> m_values;
+    QList<qreal> m_values, m_xAxisValues;
     QList<QString> m_labels;
     QList<QColor> m_colors;
 };
@@ -30,6 +31,7 @@ class SeriesItem : public QObject{
     Q_PROPERTY(QString name READ name WRITE setName)
     Q_PROPERTY(QString valuesColumn READ valuesColumn WRITE setValuesColumn)
     Q_PROPERTY(QString labelsColumn READ labelsColumn WRITE setLabelsColumn)
+    Q_PROPERTY(QString xAxisColumn READ xAxisColumn WRITE setXAxisColumn)
     Q_PROPERTY(QColor color READ color WRITE setColor)
     Q_PROPERTY(SeriesItemPreferredType preferredType READ preferredType WRITE setPreferredType)
 public:
@@ -46,6 +48,8 @@ public:
     void setValuesColumn(const QString &valuesColumn);
     QString labelsColumn() const;
     void setLabelsColumn(const QString &labelsColumn);
+    QString xAxisColumn() const;
+    void setXAxisColumn(const QString &xAxisColumn);
     SeriesItem* clone();
     void fillSeriesData(IDataSource* dataSource);
     SeriesItemData* data(){ return &m_data;}
@@ -58,6 +62,7 @@ private:
     QString m_name;
     QString m_valuesColumn;
     QString m_labelsColumn;
+    QString m_xAxisColumn;
     SeriesItemData m_data;
     QColor m_color;
     SeriesItemPreferredType m_preferredType;
@@ -86,7 +91,8 @@ public:
 protected:
     qreal maxValue();
     qreal minValue();
-    AxisData yAxisData();
+    qreal maxXValue();
+    qreal minXValue();
     void updateMinAndMaxValues();
     int valuesCount();
     int seriesCount();
@@ -136,6 +142,8 @@ class ChartItem : public LimeReport::ItemDesignIntf
     //linesChart
     Q_PROPERTY(bool drawPoints READ drawPoints WRITE setDrawPoints)
     Q_PROPERTY(int seriesLineWidth READ seriesLineWidth WRITE setSeriesLineWidth)
+    Q_PROPERTY(bool horizontalAxisOnTop READ horizontalAxisOnTop WRITE setHorizontalAxisOnTop)
+    Q_PROPERTY(QString xAxisField READ xAxisField WRITE setXAxisField)
     friend class AbstractChart;
 public:
 
@@ -194,6 +202,12 @@ public:
     int seriesLineWidth() const;
     void setSeriesLineWidth(int newSeriesLineWidth);
 
+    QString xAxisField() const;
+    void setXAxisField(const QString &xAxisField);
+
+    bool horizontalAxisOnTop() const;
+    void setHorizontalAxisOnTop(bool horizontalAxisOnTop);
+
 protected:
     void paintChartTitle(QPainter* painter, QRectF titleRect);
     virtual BaseDesignIntf* createSameTypeItem(QObject *owner, QGraphicsItem *parent);
@@ -222,6 +236,8 @@ private:
     bool m_showLegend;
     bool m_drawPoints;
     int m_seriesLineWidth;
+    QString m_xAxisField;
+    bool m_horizontalAxisOnTop;
 };
 } //namespace LimeReport
 #endif // LRCHARTITEM_H

--- a/limereport/items/lrchartitem.h
+++ b/limereport/items/lrchartitem.h
@@ -89,10 +89,10 @@ class AbstractSeriesChart: public AbstractChart{
 public:
     AbstractSeriesChart(ChartItem* chartItem);
 protected:
+    AxisData yAxisData();
+    AxisData xAxisData();
     qreal maxValue();
     qreal minValue();
-    qreal maxXValue();
-    qreal minXValue();
     void updateMinAndMaxValues();
     int valuesCount();
     int seriesCount();
@@ -113,7 +113,7 @@ protected:
     virtual QString verticalLabel(int i, qreal step, qreal min);
 
 private:
-    AxisData m_yAxisData;
+    AxisData m_yAxisData, m_xAxisData;
     qreal m_designValues [9];
 };
 

--- a/limereport/items/lrchartitem.h
+++ b/limereport/items/lrchartitem.h
@@ -110,7 +110,7 @@ protected:
     virtual qreal valuesHMargin(QPainter *painter);
     virtual qreal valuesVMargin(QPainter *painter);
     virtual QFont adaptLabelsFont(QRectF rect, QFont font);
-    virtual QFont adaptValuesFont(qreal width, QFont font);
+    virtual QFont adaptFont(qreal width, QFont font, const AxisData &axisData);
     virtual QString axisLabel(int i, const AxisData &axisData);
 
 private:

--- a/limereport/items/lrchartitem.h
+++ b/limereport/items/lrchartitem.h
@@ -104,13 +104,14 @@ protected:
     virtual void paintHorizontalLabels(QPainter *painter, QRectF labelsRect);
     virtual void paintVerticalLabels(QPainter *painter, QRectF labelsRect);
     virtual void paintHorizontalGrid(QPainter *painter, QRectF gridRect);
+    virtual void paintGrid(QPainter *painter, QRectF gridRect);
     virtual void paintVerticalGrid(QPainter *painter, QRectF gridRect);
     virtual void drawSegment(QPainter *painter, QPoint startPoint, QPoint endPoint, QColor color);
     virtual qreal valuesHMargin(QPainter *painter);
     virtual qreal valuesVMargin(QPainter *painter);
     virtual QFont adaptLabelsFont(QRectF rect, QFont font);
     virtual QFont adaptValuesFont(qreal width, QFont font);
-    virtual QString verticalLabel(int i, qreal step, qreal min);
+    virtual QString axisLabel(int i, const AxisData &axisData);
 
 private:
     AxisData m_yAxisData, m_xAxisData;
@@ -148,8 +149,9 @@ class ChartItem : public LimeReport::ItemDesignIntf
 public:
 
     enum LegendAlign{LegendAlignTop,LegendAlignCenter,LegendAlignBottom};
+    enum LegendStyle{LegendPoints, LegendLines};
     enum TitleAlign{TitleAlignLeft, TitleAlignCenter, TitleAlignRight};
-    enum ChartType{Pie, VerticalBar, HorizontalBar, Lines};
+    enum ChartType{Pie, VerticalBar, HorizontalBar, Lines, GridLines};
 #if QT_VERSION >= 0x050500
     Q_ENUM(LegendAlign)
     Q_ENUM(TitleAlign)

--- a/limereport/items/lrchartitemeditor.cpp
+++ b/limereport/items/lrchartitemeditor.cpp
@@ -23,6 +23,8 @@ ChartItemEditor::ChartItemEditor(LimeReport::ChartItem *item, LimeReport::PageDe
     readSetting();
     init();
     connect(m_colorButton, SIGNAL(clicked(bool)), this, SLOT(slotChangeSeriesColor()));
+
+    // TODO_ES add field in editor for x axis field, like for labels
 }
 
 ChartItemEditor::~ChartItemEditor()

--- a/limereport/items/lrchartitemeditor.cpp
+++ b/limereport/items/lrchartitemeditor.cpp
@@ -23,8 +23,6 @@ ChartItemEditor::ChartItemEditor(LimeReport::ChartItem *item, LimeReport::PageDe
     readSetting();
     init();
     connect(m_colorButton, SIGNAL(clicked(bool)), this, SLOT(slotChangeSeriesColor()));
-
-    // TODO_ES add field in editor for x axis field, like for labels
 }
 
 ChartItemEditor::~ChartItemEditor()
@@ -108,6 +106,7 @@ void ChartItemEditor::init()
                 for (int i=0;i<ds->columnCount();++i){
                    ui->valuesFieldComboBox->addItem(ds->columnNameByIndex(i));
                    ui->labelsFieldComboBox->addItem(ds->columnNameByIndex(i));
+                   ui->xAxisFieldComboBox->addItem(ds->columnNameByIndex(i));
                 }
             }
         }
@@ -122,8 +121,10 @@ void ChartItemEditor::init()
 
 #if QT_VERSION < 0x050000
     ui->labelsFieldComboBox->setCurrentIndex(ui->labelsFieldComboBox->findText( m_charItem->labelsField()));
+    ui->xAxisFieldComboBox->setCurrentIndex(ui->xAxisFieldComboBox->findText( m_charItem->xAxisField()));
 #else
     ui->labelsFieldComboBox->setCurrentText(m_charItem->labelsField());
+    ui->xAxisFieldComboBox->setCurrentText(m_charItem->xAxisField());
 #endif
     if (!m_charItem->series().isEmpty()){
         enableSeriesEditor();
@@ -288,4 +289,10 @@ void ChartItemEditor::on_seriesTypeComboBox_currentIndexChanged(const QString &a
     if (currentSeries()){
         currentSeries()->setPreferredType(static_cast<LimeReport::SeriesItem::SeriesItemPreferredType>(enumerator.keysToValue(arg1.toLatin1())));
     }
+}
+
+void ChartItemEditor::on_xAxisFieldComboBox_currentTextChanged(const QString &arg1)
+{
+    if (!m_initing)
+        m_charItem->setXAxisField(arg1);
 }

--- a/limereport/items/lrchartitemeditor.h
+++ b/limereport/items/lrchartitemeditor.h
@@ -41,6 +41,8 @@ private slots:
     void slotChangeSeriesColor();
     void on_seriesTypeComboBox_currentIndexChanged(const QString &arg1);
 
+    void on_xAxisFieldComboBox_currentTextChanged(const QString &arg1);
+
 private:
     void readSetting();
     void writeSetting();

--- a/limereport/items/lrchartitemeditor.ui
+++ b/limereport/items/lrchartitemeditor.ui
@@ -144,16 +144,30 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="1">
+      <widget class="QComboBox" name="labelsFieldComboBox">
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
       <widget class="QLabel" name="labelsFieldLabel">
        <property name="text">
         <string>Labels field</string>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QComboBox" name="labelsFieldComboBox">
+     <item row="1" column="0">
+      <widget class="QLabel" name="xAxisFieldLabel">
+       <property name="text">
+        <string>X data field</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="xAxisFieldComboBox">
        <property name="editable">
         <bool>true</bool>
        </property>

--- a/limereport/limereport.pri
+++ b/limereport/limereport.pri
@@ -49,6 +49,7 @@ SOURCES += \
     $$REPORT_PATH/items/lrchartitemeditor.cpp \
     $$REPORT_PATH/items/charts/lrhorizontalbarchart.cpp \
     $$REPORT_PATH/items/charts/lrlineschart.cpp \
+    $$REPORT_PATH/items/charts/lrgridlineschart.cpp \
     $$REPORT_PATH/items/charts/lrpiechart.cpp \
     $$REPORT_PATH/items/charts/lrverticalbarchart.cpp \
     $$REPORT_PATH/lrbanddesignintf.cpp \
@@ -132,6 +133,7 @@ HEADERS += \
     $$REPORT_PATH/items/lrchartitemeditor.h \
     $$REPORT_PATH/items/charts/lrhorizontalbarchart.h \
     $$REPORT_PATH/items/charts/lrlineschart.h \
+    $$REPORT_PATH/items/charts/lrgridlineschart.h \
     $$REPORT_PATH/items/charts/lrpiechart.h \
     $$REPORT_PATH/items/charts/lrverticalbarchart.h \
     $$REPORT_PATH/lrbanddesignintf.h \

--- a/limereport/lraxisdata.cpp
+++ b/limereport/lraxisdata.cpp
@@ -53,16 +53,6 @@ qreal AxisData::delta() const
     return m_delta;
 }
 
-bool AxisData::reverseDirection() const
-{
-    return m_reverseDirection;
-}
-
-void AxisData::setReverseDirection(bool reverseDirection)
-{
-    m_reverseDirection = reverseDirection;
-}
-
 void AxisData::calculateValuesAboveMax(qreal minValue, qreal maxValue, int segments)
 {
     const int delta = maxValue - minValue;

--- a/limereport/lraxisdata.cpp
+++ b/limereport/lraxisdata.cpp
@@ -53,6 +53,16 @@ qreal AxisData::delta() const
     return m_delta;
 }
 
+bool AxisData::reverseDirection() const
+{
+    return m_reverseDirection;
+}
+
+void AxisData::setReverseDirection(bool reverseDirection)
+{
+    m_reverseDirection = reverseDirection;
+}
+
 void AxisData::calculateValuesAboveMax(qreal minValue, qreal maxValue, int segments)
 {
     const int delta = maxValue - minValue;

--- a/limereport/lraxisdata.h
+++ b/limereport/lraxisdata.h
@@ -20,9 +20,12 @@ public:
     qreal step() const;
 
     qreal delta() const;
+
+    bool reverseDirection() const;
+    void setReverseDirection(bool reverseDirection);
+
 private:
     void calculateValuesAboveMax(qreal minValue, qreal maxValue, int segments);
-    qreal calculateNiceNum(qreal range, bool round);
 
     qreal m_rangeMin;
     qreal m_rangeMax;
@@ -31,6 +34,7 @@ private:
     qreal m_step;
     qreal m_delta;
     int m_segmentCount;
+    bool m_reverseDirection;
 };
 };
 

--- a/limereport/lraxisdata.h
+++ b/limereport/lraxisdata.h
@@ -21,9 +21,6 @@ public:
 
     qreal delta() const;
 
-    bool reverseDirection() const;
-    void setReverseDirection(bool reverseDirection);
-
 private:
     void calculateValuesAboveMax(qreal minValue, qreal maxValue, int segments);
 
@@ -34,7 +31,6 @@ private:
     qreal m_step;
     qreal m_delta;
     int m_segmentCount;
-    bool m_reverseDirection;
 };
 };
 

--- a/limereport/objectinspector/lrobjectitemmodel.cpp
+++ b/limereport/objectinspector/lrobjectitemmodel.cpp
@@ -144,6 +144,7 @@ void QObjectPropertyModel::translatePropertyName()
     tr("chartType");
     tr("drawLegendBorder");
     tr("labelsField");
+    tr("xAxisField");
     tr("legendAlign");
     tr("series");
     tr("titleAlign");

--- a/limereport/objectinspector/lrobjectitemmodel.cpp
+++ b/limereport/objectinspector/lrobjectitemmodel.cpp
@@ -171,6 +171,8 @@ void QObjectPropertyModel::translatePropertyName()
     tr("removeGap");
     tr("dropPrinterMargins");
     tr("notPrintIfEmpty");
+    tr("gridChartLines");
+    tr("horizontalAxisOnTop");
     tr("mixWithPriorPage");
 }
 


### PR DESCRIPTION
* Added new Grid lines chart type. It contains both x and y axes
* Added horizontalAxisOnTop property to draw horizontal labels to be drawn at the top of chart instead bottom
* Added x axis data field. Chart editor widget was updated with new field. X axis is only applied to GridLines chart type
* Added property to GridChartLines, it allows user to not draw horizontal or vertical lines inside grid.
* Updated adapt font and axis label methods to be universal for both axes

Added file for testing:
[grid_lines_chart.zip](https://github.com/fralx/LimeReport/files/7966401/grid_lines_chart.zip)

Images:
![image](https://user-images.githubusercontent.com/11396062/151709048-9213c83e-b078-420a-9aa5-d038e3495c55.png)

![image](https://user-images.githubusercontent.com/11396062/151709057-fcf47ddf-d595-4ee4-aba8-571d8142c714.png)

