### PR TITLE
Designer fix: undoing delete layout inside the layout

### DIFF
--- a/limereport/items/lrabstractlayout.cpp
+++ b/limereport/items/lrabstractlayout.cpp
@@ -273,8 +273,10 @@ void AbstractLayout::connectToLayout(BaseDesignIntf *item)
         item, SIGNAL(itemSelectedHasBeenChanged(BaseDesignIntf*,bool)),
         this, SLOT(slotOnChildSelectionHasChanged(BaseDesignIntf*,bool))
         );
-    connect(item, SIGNAL(itemAlignChanged(BaseDesignIntf*,ItemAlign,ItemAlign)),
-            this, SLOT(slotOnChildItemAlignChanged(BaseDesignIntf*,ItemAlign,ItemAlign)));
+    connect(
+        item, SIGNAL(itemAlignChanged(BaseDesignIntf*, const ItemAlign&, const ItemAlign&)),
+        this, SLOT(slotOnChildItemAlignChanged(BaseDesignIntf*,const ItemAlign&,const ItemAlign&))
+        );
 }
 
 void AbstractLayout::disconnectFromLayout(BaseDesignIntf *item)
@@ -295,8 +297,10 @@ void AbstractLayout::disconnectFromLayout(BaseDesignIntf *item)
         item, SIGNAL(itemSelectedHasBeenChanged(BaseDesignIntf*,bool)),
         this, SLOT(slotOnChildSelectionHasChanged(BaseDesignIntf*,bool))
         );
-    disconnect(item, SIGNAL(itemAlignChanged(BaseDesignIntf*,ItemAlign,ItemAlign)),
-            this, SLOT(slotOnChildItemAlignChanged(BaseDesignIntf*,ItemAlign,ItemAlign)));
+    disconnect(
+        item, SIGNAL(itemAlignChanged(BaseDesignIntf*, const ItemAlign&, const ItemAlign&)),
+        this, SLOT(slotOnChildItemAlignChanged(BaseDesignIntf*,const ItemAlign&,const ItemAlign&))
+        );
 }
 
 BaseDesignIntf *AbstractLayout::findNext(BaseDesignIntf *item)
@@ -348,7 +352,7 @@ void AbstractLayout::slotOnChildGeometryChanged(QObject* item, QRectF newGeometr
     }
 }
 
-void AbstractLayout::slotOnChildItemAlignChanged(BaseDesignIntf* item, const BaseDesignIntf::ItemAlign&, const BaseDesignIntf::ItemAlign&)
+void AbstractLayout::slotOnChildItemAlignChanged(BaseDesignIntf* item, const ItemAlign&, const ItemAlign&)
 {
     item->setPossibleResizeDirectionFlags(ResizeBottom | ResizeRight);
 }

--- a/limereport/items/lrabstractlayout.cpp
+++ b/limereport/items/lrabstractlayout.cpp
@@ -293,7 +293,7 @@ BaseDesignIntf *AbstractLayout::findPrior(BaseDesignIntf *item)
 void AbstractLayout::slotOnChildDestroy(QObject* child)
 {
     m_children.removeAll(static_cast<BaseDesignIntf*>(child));
-    if (m_children.count()<2){
+    if (m_children.count() < 2 && !static_cast<LayoutDesignIntf*>(child)){
         beforeDelete();
     } else {
         relocateChildren();

--- a/limereport/items/lrabstractlayout.cpp
+++ b/limereport/items/lrabstractlayout.cpp
@@ -57,22 +57,7 @@ void AbstractLayout::addChild(BaseDesignIntf* item, bool updateSize)
     item->setFixedPos(true);
     item->setPossibleResizeDirectionFlags(ResizeRight | ResizeBottom);
 
-    connect(
-        item, SIGNAL(destroyed(QObject*)),
-        this, SLOT(slotOnChildDestroy(QObject*))
-    );
-    connect(
-        item,SIGNAL(geometryChanged(QObject*,QRectF,QRectF)),
-        this,SLOT(slotOnChildGeometryChanged(QObject*,QRectF,QRectF))
-    );
-    connect(
-        item, SIGNAL(itemVisibleHasChanged(BaseDesignIntf*)),
-        this, SLOT(slotOnChildVisibleHasChanged(BaseDesignIntf*))
-    );
-    connect(
-        item, SIGNAL(itemSelectedHasBeenChanged(BaseDesignIntf*,bool)),
-        this, SLOT(slotOnChildSelectionHasChanged(BaseDesignIntf*,bool))
-    );
+    connectTolayout(item);
 
     if (updateSize){
         relocateChildren();
@@ -265,6 +250,26 @@ void AbstractLayout::rebuildChildrenIfNeeded(){
         }
         sortChildren();
     }
+}
+
+void AbstractLayout::connectTolayout(BaseDesignIntf *item)
+{
+    connect(
+        item, SIGNAL(destroyed(QObject*)),
+        this, SLOT(slotOnChildDestroy(QObject*))
+        );
+    connect(
+        item,SIGNAL(geometryChanged(QObject*,QRectF,QRectF)),
+        this,SLOT(slotOnChildGeometryChanged(QObject*,QRectF,QRectF))
+        );
+    connect(
+        item, SIGNAL(itemVisibleHasChanged(BaseDesignIntf*)),
+        this, SLOT(slotOnChildVisibleHasChanged(BaseDesignIntf*))
+        );
+    connect(
+        item, SIGNAL(itemSelectedHasBeenChanged(BaseDesignIntf*,bool)),
+        this, SLOT(slotOnChildSelectionHasChanged(BaseDesignIntf*,bool))
+        );
 }
 
 BaseDesignIntf *AbstractLayout::findNext(BaseDesignIntf *item)

--- a/limereport/items/lrabstractlayout.h
+++ b/limereport/items/lrabstractlayout.h
@@ -28,6 +28,7 @@ public:
     void setLayoutType(const LayoutType& layoutType);
 
     void addChild(BaseDesignIntf *item,bool updateSize=true);
+    void removeChild(BaseDesignIntf *item);
     void restoreChild(BaseDesignIntf *item);
     bool isEmpty() const;
     void paintChild(BaseDesignIntf* child, QPointF parentPos, QPainter* painter);
@@ -52,7 +53,8 @@ protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant &value);
     void updateItemSize(DataSourceManager* dataManager, RenderPass pass, int maxHeight);
     void rebuildChildrenIfNeeded();
-    void connectTolayout(BaseDesignIntf* item);
+    void connectToLayout(BaseDesignIntf* item);
+    void disconnectFromLayout(BaseDesignIntf* item);
 private:
     virtual void sortChildren() = 0;
     virtual void divideSpace() = 0;

--- a/limereport/items/lrabstractlayout.h
+++ b/limereport/items/lrabstractlayout.h
@@ -52,6 +52,7 @@ protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant &value);
     void updateItemSize(DataSourceManager* dataManager, RenderPass pass, int maxHeight);
     void rebuildChildrenIfNeeded();
+    void connectTolayout(BaseDesignIntf* item);
 private:
     virtual void sortChildren() = 0;
     virtual void divideSpace() = 0;

--- a/limereport/items/lrhorizontallayout.cpp
+++ b/limereport/items/lrhorizontallayout.cpp
@@ -171,9 +171,14 @@ void HorizontalLayout::updateLayoutSize()
 void HorizontalLayout::relocateChildren()
 {
     int spaceBorder = (borderLines() != 0) ? borderLineSize() : 0;
+    QList<BaseDesignIntf*> newChildren;
     if (layoutsChildren().count() < childItems().size()-1){
+        auto oldChildren = layoutsChildren();
         layoutsChildren().clear();
         foreach (BaseDesignIntf* item, childBaseItems()) {
+            if (!oldChildren.contains(item)) {
+                newChildren.append(item);
+            }
             layoutsChildren().append(item);
         }
     }
@@ -188,6 +193,10 @@ void HorizontalLayout::relocateChildren()
         }
     }
     setIsRelocating(false);
+
+    for (BaseDesignIntf* item : newChildren) {
+        connectTolayout(item);
+    }
 }
 
 void HorizontalLayout::divideSpace(){

--- a/limereport/items/lrhorizontallayout.cpp
+++ b/limereport/items/lrhorizontallayout.cpp
@@ -195,7 +195,7 @@ void HorizontalLayout::relocateChildren()
     setIsRelocating(false);
 
     for (BaseDesignIntf* item : newChildren) {
-        connectTolayout(item);
+        connectToLayout(item);
     }
 }
 

--- a/limereport/items/lrverticallayout.cpp
+++ b/limereport/items/lrverticallayout.cpp
@@ -57,9 +57,14 @@ void VerticalLayout::updateLayoutSize()
 void VerticalLayout::relocateChildren()
 {
     int spaceBorder = (borderLines() != 0) ? borderLineSize() : 0;
+    QList<BaseDesignIntf*> newChildren;
     if (layoutsChildren().count() < childItems().size() - 1){
+        auto oldChildren = layoutsChildren();
         layoutsChildren().clear();
         foreach (BaseDesignIntf* item, childBaseItems()) {
+            if (!oldChildren.contains(item)) {
+                newChildren.append(item);
+            }
             layoutsChildren().append(item);
         }
     }
@@ -74,6 +79,10 @@ void VerticalLayout::relocateChildren()
         }
     }
     setIsRelocating(false);
+
+    for (BaseDesignIntf* item : newChildren) {
+        connectTolayout(item);
+    }
 }
 
 bool VerticalLayout::canBeSplitted(int height) const

--- a/limereport/items/lrverticallayout.cpp
+++ b/limereport/items/lrverticallayout.cpp
@@ -81,7 +81,7 @@ void VerticalLayout::relocateChildren()
     setIsRelocating(false);
 
     for (BaseDesignIntf* item : newChildren) {
-        connectTolayout(item);
+        connectToLayout(item);
     }
 }
 

--- a/limereport/lrbasedesignintf.h
+++ b/limereport/lrbasedesignintf.h
@@ -480,7 +480,7 @@ signals:
     void propertyChanged(const QString& propertName, const QVariant& oldValue,const QVariant& newValue);
     void propertyObjectNameChanged(const QString& oldValue, const QString& newValue);
     void propertyesChanged(QVector<QString> propertyNames);
-    void itemAlignChanged(BaseDesignIntf* item, const BaseDesignIntf::ItemAlign& oldValue, const BaseDesignIntf::ItemAlign& newValue);
+    void itemAlignChanged(BaseDesignIntf* item, const ItemAlign& oldValue, const ItemAlign& newValue);
     void itemVisibleHasChanged(BaseDesignIntf* item);
     void beforeRender();
     void afterData();

--- a/limereport/lritemdesignintf.h
+++ b/limereport/lritemdesignintf.h
@@ -97,6 +97,7 @@ public:
     LayoutDesignIntf(const QString& xmlTypeName, QObject* owner = 0,QGraphicsItem* parent = 0):
         ItemDesignIntf(xmlTypeName,owner,parent){}
     virtual void addChild(BaseDesignIntf *item,bool updateSize=true) = 0;
+    virtual void removeChild(BaseDesignIntf *item) = 0;
     virtual void restoreChild(BaseDesignIntf *item) = 0;
     virtual int childrenCount() = 0;
     friend class BaseDesignIntf;

--- a/limereport/lrpagedesignintf.cpp
+++ b/limereport/lrpagedesignintf.cpp
@@ -554,17 +554,16 @@ CommandIf::Ptr PageDesignIntf::removeReportItemCommand(BaseDesignIntf *item){
         CommandIf::Ptr command = createBandDeleteCommand(this,band);
         return command;
     } else {
-        LayoutDesignIntf* layout = dynamic_cast<LayoutDesignIntf*>(item->parent());
-        if (layout && (layout->childrenCount()==2)){
+        LayoutDesignIntf* parentLayout = dynamic_cast<LayoutDesignIntf*>(item->parent());
+        LayoutDesignIntf* layout = dynamic_cast<LayoutDesignIntf*>(item);
+        // When removing layout child all his children will be assigned to parent
+        if (!layout && parentLayout && (parentLayout->childrenCount() == 2)) {
             CommandGroup::Ptr commandGroup = CommandGroup::create();
-            commandGroup->addCommand(DeleteLayoutCommand::create(this, layout),false);
+            commandGroup->addCommand(DeleteLayoutCommand::create(this, parentLayout),false);
             commandGroup->addCommand(DeleteItemCommand::create(this,item),false);
             return commandGroup;
         } else {
-            CommandIf::Ptr command = (dynamic_cast<LayoutDesignIntf*>(item))?
-                        DeleteLayoutCommand::create(this, dynamic_cast<LayoutDesignIntf*>(item)) :
-                        DeleteItemCommand::create(this, item) ;
-            return command;
+            return layout ? DeleteLayoutCommand::create(this, layout) : DeleteItemCommand::create(this, item) ;
         }
     }
 }

--- a/limereport/lrpagedesignintf.h
+++ b/limereport/lrpagedesignintf.h
@@ -415,6 +415,7 @@ namespace LimeReport {
         void setItem(BaseDesignIntf* item);
     private:
         QStringList m_childItems;
+        QString m_layoutName;
         QString m_itemXML;
         QString m_itemType;
         QString m_itemName;

--- a/limereport/objectinspector/lrobjectitemmodel.cpp
+++ b/limereport/objectinspector/lrobjectitemmodel.cpp
@@ -222,6 +222,10 @@ void QObjectPropertyModel::setMultiObjects(QList<QObject *>* list)
     m_objects.clear();
     submit();
 
+    if (list->isEmpty()) {
+        return;
+    }
+
     if (!list->contains(m_object)){
         m_object=list->at(0);
         list->removeAt(0);


### PR DESCRIPTION
Crash fixes:
* Rare crash when copying or deleting selected items (empty list assessed at first position)

Bug fixes:
* Removing item when in layout and that layout was in other layout with another item would cause to remove both layouts. Test A in file, delete any item in vertical layout, horizontal layout will be preserved
* Removing item same way as above would not connect it correctly to layout, causing issues when resizing (check Test B in file
* Undoing removal of item as above would not correctly recreate item connections to restored layout, causing glitches and bugged behaviour

File:
[lr_git_test.zip](https://github.com/fralx/LimeReport/files/8013223/lr_git_test.zip)

