### PR TITLE
Feature/add horizontal legend

### DIFF
--- a/limereport/items/charts/lrpiechart.cpp
+++ b/limereport/items/charts/lrpiechart.cpp
@@ -91,7 +91,6 @@ void PieChart::paintChart(QPainter *painter, QRectF chartRect)
 
 void PieChart::paintChartLegend(QPainter *painter, QRectF legendRect)
 {
-// TODO_ES Fix bottom legend when axis is at the bottom
     prepareLegendToPaint(legendRect, painter);
 
     int indicatorSize = painter->fontMetrics().height()/2;

--- a/limereport/items/charts/lrpiechart.cpp
+++ b/limereport/items/charts/lrpiechart.cpp
@@ -91,6 +91,7 @@ void PieChart::paintChart(QPainter *painter, QRectF chartRect)
 
 void PieChart::paintChartLegend(QPainter *painter, QRectF legendRect)
 {
+// TODO_ES Fix bottom legend when axis is at the bottom
     prepareLegendToPaint(legendRect, painter);
 
     int indicatorSize = painter->fontMetrics().height()/2;
@@ -143,7 +144,7 @@ void PieChart::paintChartLegend(QPainter *painter, QRectF legendRect)
     }
 }
 
-QSizeF PieChart::calcChartLegendSize(const QFont &font)
+QSizeF PieChart::calcChartLegendSize(const QFont &font, qreal)
 {
     QFontMetrics fm(font);
 

--- a/limereport/items/charts/lrpiechart.h
+++ b/limereport/items/charts/lrpiechart.h
@@ -8,7 +8,7 @@ namespace LimeReport{
 class PieChart : public AbstractChart{
 public:
     PieChart(ChartItem* chartItem):AbstractChart(chartItem){}
-    QSizeF calcChartLegendSize(const QFont &font);
+    QSizeF calcChartLegendSize(const QFont &font, qreal maxWidth = 0);
     void paintChart(QPainter *painter, QRectF chartRect);
     void paintChartLegend(QPainter *painter, QRectF legendRect);
 protected:

--- a/limereport/items/lrchartitem.cpp
+++ b/limereport/items/lrchartitem.cpp
@@ -197,28 +197,25 @@ void ChartItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
 
     const QRectF titleRect = QRectF(borderMargin,borderMargin,rect().width()-borderMargin*2,titleOffset);
     QRectF legendRect = QRectF(0, 0, 0, 0);
-    QRectF diagramRect = QRectF(0, 0, 0, 0);
+    QRectF diagramRect = rect().adjusted(borderMargin, titleOffset + borderMargin,
+                                         -(borderMargin * 2), -borderMargin);
     if (m_showLegend) {
         legendRect = m_chart->calcChartLegendRect(painter->font(), rect(), false, borderMargin, titleOffset);
         switch(legendAlign()) {
         case LegendAlignRightTop:
         case LegendAlignRightBottom:
         case LegendAlignRightCenter:
-            diagramRect = rect().adjusted(borderMargin, titleOffset + borderMargin,
-                                          -(legendRect.width() + borderMargin * 2), -borderMargin);
+            diagramRect.adjust(0, 0, -legendRect.width(), 0);
             break;
         case LegendAlignBottomLeft:
         case LegendAlignBottomCenter:
         case LegendAlignBottomRight:
-            diagramRect = rect().adjusted(borderMargin, titleOffset + borderMargin,
-                                          (borderMargin * 2), -legendRect.height());
+            diagramRect.adjust(0, 0, 0, -(legendRect.height() + borderMargin * 2));
             break;
         }
-    } else {
-        diagramRect = rect().adjusted(borderMargin, titleOffset + borderMargin,
-                                      -(borderMargin * 2), -borderMargin);
     }
 
+    painter->fillRect(diagramRect, Qt::yellow);
     paintChartTitle(painter, titleRect);
     if (m_showLegend)
         m_chart->paintChartLegend(painter,legendRect);

--- a/limereport/items/lrchartitem.cpp
+++ b/limereport/items/lrchartitem.cpp
@@ -215,7 +215,6 @@ void ChartItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
         }
     }
 
-    painter->fillRect(diagramRect, Qt::yellow);
     paintChartTitle(painter, titleRect);
     if (m_showLegend)
         m_chart->paintChartLegend(painter,legendRect);
@@ -677,7 +676,7 @@ void AbstractChart::prepareLegendToPaint(QRectF &legendRect, QPainter *painter)
     case ChartItem::LegendAlignBottomLeft:
     case ChartItem::LegendAlignBottomCenter:
     case ChartItem::LegendAlignBottomRight: {
-        const qreal maxWidth = legendRect.width() * 0.9;
+        const qreal maxWidth = legendRect.width() * 0.95;
         qreal legendWidth = std::accumulate(m_legendColumnWidths.cbegin(), m_legendColumnWidths.cend(), 0.0);
         if (legendWidth < maxWidth) {
             return;
@@ -688,7 +687,6 @@ void AbstractChart::prepareLegendToPaint(QRectF &legendRect, QPainter *painter)
             legendWidth = std::accumulate(m_legendColumnWidths.cbegin(), m_legendColumnWidths.cend(), 0.0);
         }
         painter->setFont(tmpFont);
-        legendRect = calcChartLegendRect(tmpFont, legendRect, true, 0, 0);
         break;
     }
     case ChartItem::LegendAlignRightTop:
@@ -1215,7 +1213,6 @@ QVector<qreal> AbstractChart::legendColumnWidths() const
 void AbstractBarChart::paintChartLegend(QPainter *painter, QRectF legendRect)
 {
     prepareLegendToPaint(legendRect, painter);
-    // TODO_ES after calculating bottom legend size, handle difference of sizes
     painter->setPen(Qt::black);
     painter->setRenderHint(QPainter::Antialiasing,false);
     if (m_chartItem->drawLegendBorder())

--- a/limereport/items/lrchartitem.h
+++ b/limereport/items/lrchartitem.h
@@ -124,7 +124,7 @@ protected:
 private:
     bool calculateLegendColumnWidths(qreal indicatorWidth, qreal maxWidth, const QFontMetrics &fm);
     bool calculateLegendSingleColumnWidth(qreal &currentRowWidth, int &currentColumn, int &maxColumnCount,
-                                          const qreal itemWidth, const qreal maxWidth);
+                                          const qreal itemWidth, const qreal maxRowWidth);
     AxisData m_yAxisData, m_xAxisData;
     qreal m_designValues [9];
 };


### PR DESCRIPTION
* Added horizontal legend (below diagram). It can have 3 positions
* Added line indicator for legends

Horizontal legend columns are calculated depending on text size and with rule that next rows cannot have more columns than previous rows and each column has same width in every row. 
For example 1st row has 3 columns, then 2nd row cannot have 4 columns, but can have 1, 2 or 3.

![image](https://user-images.githubusercontent.com/11396062/156926793-345aa503-9e60-41e1-bee3-8f214b323410.png)


Report file for testing, it contains pages with different diagram types:
[lr_git_test.zip](https://github.com/fralx/LimeReport/files/8192733/lr_git_test.zip)

