### PR TITLE
Bugfix/changing name using table widget

### DIFF
--- a/limereport/items/lrchartitemeditor.cpp
+++ b/limereport/items/lrchartitemeditor.cpp
@@ -296,3 +296,14 @@ void ChartItemEditor::on_xAxisFieldComboBox_currentTextChanged(const QString &ar
     if (!m_initing)
         m_charItem->setXAxisField(arg1);
 }
+void ChartItemEditor::on_tableWidget_itemChanged(QTableWidgetItem *item)
+{
+    if (ui->seriesNameLineEdit->hasFocus())
+        return;
+
+    const QString dataStr = item->data(Qt::DisplayRole).toString();
+    if (dataStr == ui->seriesNameLineEdit->text())
+        return;
+
+    ui->seriesNameLineEdit->setText(dataStr);
+}

--- a/limereport/items/lrchartitemeditor.h
+++ b/limereport/items/lrchartitemeditor.h
@@ -40,8 +40,8 @@ private slots:
     void on_labelsFieldComboBox_currentTextChanged(const QString &arg1);
     void slotChangeSeriesColor();
     void on_seriesTypeComboBox_currentIndexChanged(const QString &arg1);
-
     void on_xAxisFieldComboBox_currentTextChanged(const QString &arg1);
+    void on_tableWidget_itemChanged(QTableWidgetItem *item);
 
 private:
     void readSetting();


### PR DESCRIPTION
Fixed a bug where changing name in Series Editor using double click in table widget would change name in table widget cell but it wouldn't be applied to actual series name.

![image](https://user-images.githubusercontent.com/11396062/158197772-5ca33acc-be66-4b38-b662-60776375dd8a.png)
