### PR TITLE
Fix cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(limereport)
 cmake_minimum_required(VERSION 3.14)
+project(limereport)
 
 set(LIMEREPORT_VERSION_MAJOR 1)
 set(LIMEREPORT_VERSION_MINOR 6)


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html 

> Call the cmake_minimum_required() command at the beginning of the top-level CMakeLists.txt file even before calling the project() command. It is important to establish version and policy settings before invoking other commands whose behavior they may affect.