### PR TITLE
Fix qmake version generator

### DIFF
--- a/limereport/limereport.pri
+++ b/limereport/limereport.pri
@@ -215,7 +215,7 @@ RESOURCES += \
     $$REPORT_PATH/items/items.qrc
 
 system("git --version") {
-    LR_VERSION = $$system("git --git-dir=$$PWD/../.git describe --tags --dirty")
+    LR_VERSION = $$system("git --git-dir=$$PWD/../.git --work-tree=$$PWD/.. describe --tags --dirty")
 } else {
     LR_VERSION = "0.0.0-unknown"
 }


### PR DESCRIPTION
cmake's `execute_process()` has `WORKING_DIRECTORY` parameter, but qmake's `$$system()` does not.

As a workaround for qmake, `git` command was called with `--git-dir` provided explicitly. But for dirtyness detection we need `--work-tree`, too.

Follow-up for https://github.com/fralx/LimeReport/pull/471#issuecomment-2362114994

/cc @fralx 